### PR TITLE
tag time added to tag model

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ temp
 .couscous
 couscous.phar
 .okhttpcache
+.idea
+classes

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Here is an example template.
 Changelog of Git Changelog.
 
 {{#tags}}
-## {{name}}
+## {{name}}{{#hasTagTime}} ({{tagTime}}){{/hasTagTime}}
  {{#issues}}
   {{#hasIssue}}
    {{#hasLink}}
@@ -81,6 +81,8 @@ The template is supplied with a datastructure like:
 * tags
  - name
  - annotation
+ - tagTime
+ - hasTagTime
  * commits
   - authorName
   - authorEmailAddress

--- a/src/main/java/se/bjurr/gitchangelog/api/model/Tag.java
+++ b/src/main/java/se/bjurr/gitchangelog/api/model/Tag.java
@@ -6,6 +6,8 @@ import se.bjurr.gitchangelog.api.model.interfaces.IAuthors;
 import se.bjurr.gitchangelog.api.model.interfaces.ICommits;
 import se.bjurr.gitchangelog.api.model.interfaces.IIssues;
 
+import static com.google.common.base.Strings.isNullOrEmpty;
+
 public class Tag implements ICommits, IAuthors, IIssues, Serializable {
   private static final long serialVersionUID = 2140208294219785889L;
   private final String annotation;
@@ -14,6 +16,9 @@ public class Tag implements ICommits, IAuthors, IIssues, Serializable {
   private final List<Issue> issues;
   private final List<IssueType> issueTypes;
   private final String name;
+  private final String tagTime;
+  private final Long tagTimeLong;
+  private final boolean hasTagTime;
 
   public Tag(
       String name,
@@ -21,13 +26,18 @@ public class Tag implements ICommits, IAuthors, IIssues, Serializable {
       List<Commit> commits,
       List<Author> authors,
       List<Issue> issues,
-      List<IssueType> issueTypes) {
+      List<IssueType> issueTypes,
+      String tagTime,
+      Long tagTimeLong) {
     this.commits = commits;
     this.authors = authors;
     this.issues = issues;
     this.name = name;
     this.annotation = annotation;
     this.issueTypes = issueTypes;
+    this.tagTime = tagTime;
+    this.tagTimeLong = tagTimeLong;
+    this.hasTagTime = !isNullOrEmpty(tagTime);
   }
 
   public String getAnnotation() {
@@ -59,6 +69,18 @@ public class Tag implements ICommits, IAuthors, IIssues, Serializable {
 
   public String getName() {
     return this.name;
+  }
+
+  public String getTagTime() {
+    return this.tagTime;
+  }
+
+  public Long getTagTimeLong() {
+    return this.tagTimeLong;
+  }
+
+  public boolean isHasTagTime() {
+    return this.hasTagTime;
   }
 
   @Override

--- a/src/main/java/se/bjurr/gitchangelog/internal/git/GitRepoDataHelper.java
+++ b/src/main/java/se/bjurr/gitchangelog/internal/git/GitRepoDataHelper.java
@@ -32,7 +32,8 @@ public class GitRepoDataHelper {
             new GitTag(
                 gitTag.getName(),
                 gitTag.findAnnotation().orNull(),
-                newArrayList(reducedCommitsInTag)));
+                newArrayList(reducedCommitsInTag),
+                gitTag.getTagTime()));
       }
     }
 

--- a/src/main/java/se/bjurr/gitchangelog/internal/git/model/GitTag.java
+++ b/src/main/java/se/bjurr/gitchangelog/internal/git/model/GitTag.java
@@ -5,6 +5,8 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.common.base.Optional;
+
+import java.util.Date;
 import java.util.List;
 import se.bjurr.gitchangelog.internal.model.interfaces.IGitCommitReferer;
 
@@ -13,12 +15,14 @@ public class GitTag implements IGitCommitReferer {
   private final String annotation;
   private final List<GitCommit> gitCommits;
   private final String name;
+  private final Date tagTime;
 
-  public GitTag(String name, String annotation, List<GitCommit> gitCommits) {
+  public GitTag(String name, String annotation, List<GitCommit> gitCommits, Date tagTime) {
     checkArgument(!gitCommits.isEmpty(), "No commits in " + name);
     this.name = checkNotNull(name, "name");
     this.annotation = annotation;
     this.gitCommits = gitCommits;
+    this.tagTime = tagTime;
   }
 
   public Optional<String> findAnnotation() {
@@ -37,6 +41,10 @@ public class GitTag implements IGitCommitReferer {
   @Override
   public String getName() {
     return this.name;
+  }
+
+  public Date getTagTime() {
+    return this.tagTime;
   }
 
   @Override

--- a/src/main/java/se/bjurr/gitchangelog/internal/model/Transformer.java
+++ b/src/main/java/se/bjurr/gitchangelog/internal/model/Transformer.java
@@ -139,7 +139,9 @@ public class Transformer {
                     commits,
                     authors,
                     issues,
-                    issueTypes);
+                    issueTypes,
+                    input.getTagTime() != null ? format(input.getTagTime()) : "",
+                    input.getTagTime() != null ? input.getTagTime().getTime() : -1);
               }
 
               private List<ParsedIssue> reduceParsedIssuesToOnlyGitCommits(

--- a/src/test/resources/assertions/testTagsCommits.md
+++ b/src/test/resources/assertions/testTagsCommits.md
@@ -40,14 +40,14 @@ Adding stuff with a jira
 Adding stuff
  with gh again
 
-## test-lightweight-2
+## test-lightweight-2 (2016-02-15 16:30:35)
 
 ### Tomas Bjerre - 2016-02-15 16:30:35
 [a9bd03b34b255ff](https://server/a9bd03b34b255ff)
 
 Adding cq stuff with CQ
 
-## test-1.0
+## test-1.0 (2016-02-15 16:30:35)
 this is the tag for test-1.0&#10;
 ### Tomas Bjerre - 2016-02-15 16:30:35
 [d50a3e332f9fcba](https://server/d50a3e332f9fcba)

--- a/src/test/resources/templates/testTagsCommits.mustache
+++ b/src/test/resources/templates/testTagsCommits.mustache
@@ -3,7 +3,7 @@
 Changelog of Git Changelog.
 
 {{#tags}}
-## {{name}}
+## {{name}}{{#hasTagTime}} ({{tagTime}}){{/hasTagTime}}
 {{annotation}}
  {{#commits}}
 ### {{authorName}} - {{commitTime}}


### PR DESCRIPTION
We use gitflow and it's very convenient to generate changelog using git-changelog-lib. But without release dates it's quite uncomfortable. Please take a look.