### PR TITLE
Add ignoreCommitsOlderThan date limiting

### DIFF
--- a/src/main/java/se/bjurr/gitchangelog/api/GitChangelogApi.java
+++ b/src/main/java/se/bjurr/gitchangelog/api/GitChangelogApi.java
@@ -251,6 +251,17 @@ public class GitChangelogApi {
   }
 
   /**
+   * A date in the format given by {@link Changelog#setDateFormat()} that is evaluated on the author
+   * date of each commit. If the commit is older than the point in time given, then it will be
+   * filtered out and not included in the changelog. <br>
+   * See {@link SimpleDateFormat}.
+   */
+  public GitChangelogApi withIgnoreCommitsOlderThan(String ignoreCommitsIfOlderThan) {
+    this.settings.setIgnoreCommitsIfOlderThan(ignoreCommitsIfOlderThan);
+    return this;
+  }
+
+  /**
    * If a commit cannot be mapped to any issue, it can be added to the virtual " {@link
    * GitChangelogApi#withNoIssueName no issue}"-issue.<br>
    * <br>

--- a/src/main/java/se/bjurr/gitchangelog/api/GitChangelogApiConstants.java
+++ b/src/main/java/se/bjurr/gitchangelog/api/GitChangelogApiConstants.java
@@ -10,6 +10,7 @@ public final class GitChangelogApiConstants {
   public static final String DEFAULT_DATEFORMAT = "YYYY-MM-dd HH:mm:ss";
   public static final String DEFAULT_IGNORE_COMMITS_REGEXP =
       "^\\[maven-release-plugin\\].*|^\\[Gradle Release Plugin\\].*|^Merge.*";
+  public static final String DEFAULT_IGNORE_COMMITS_DATE = "";
   public static final String DEFAULT_UNTAGGED_NAME = "Unreleased";
   public static final String DEFAULT_READABLE_TAG_NAME = "/([^/]+?)$";
   public static final String DEFAULT_NO_ISSUE_NAME = "No issue";

--- a/src/main/java/se/bjurr/gitchangelog/internal/common/GitPredicates.java
+++ b/src/main/java/se/bjurr/gitchangelog/internal/common/GitPredicates.java
@@ -4,17 +4,35 @@ import static java.util.regex.Pattern.DOTALL;
 import static java.util.regex.Pattern.compile;
 
 import com.google.common.base.Predicate;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
 import se.bjurr.gitchangelog.internal.git.model.GitCommit;
 
 public class GitPredicates {
 
-  public static Predicate<GitCommit> ignoreCommits(final String ignoreCommitsIfMessageMatches) {
+  public static Predicate<GitCommit> ignoreCommits(
+      final String ignoreCommitsIfMessageMatches,
+      final String ignoreCommitsIfOlderThan,
+      final String dateFormat) {
     return new Predicate<GitCommit>() {
+      private SimpleDateFormat dateFormatter = new SimpleDateFormat(dateFormat);
+
       @Override
       public boolean apply(GitCommit gitCommit) {
-        return !compile(ignoreCommitsIfMessageMatches, DOTALL)
-            .matcher(gitCommit.getMessage())
-            .matches();
+        boolean messageMatches =
+            compile(ignoreCommitsIfMessageMatches, DOTALL)
+                .matcher(gitCommit.getMessage())
+                .matches();
+
+        boolean olderThan;
+        try {
+          olderThan =
+              gitCommit.getCommitTime().before(dateFormatter.parse(ignoreCommitsIfOlderThan));
+        } catch (ParseException e) {
+          olderThan = false;
+        }
+
+        return !messageMatches && !olderThan;
       }
     };
   }

--- a/src/main/java/se/bjurr/gitchangelog/internal/model/Transformer.java
+++ b/src/main/java/se/bjurr/gitchangelog/internal/model/Transformer.java
@@ -80,7 +80,12 @@ public class Transformer {
 
   public List<Commit> toCommits(Collection<GitCommit> from) {
     Iterable<GitCommit> filteredCommits =
-        filter(from, ignoreCommits(this.settings.getIgnoreCommitsIfMessageMatches()));
+        filter(
+            from,
+            ignoreCommits(
+                this.settings.getIgnoreCommitsIfMessageMatches(),
+                this.settings.getIgnoreCommitsIfOlderThan(),
+                this.settings.getDateFormat()));
     return newArrayList(
         transform(
             filteredCommits,

--- a/src/main/java/se/bjurr/gitchangelog/internal/settings/Settings.java
+++ b/src/main/java/se/bjurr/gitchangelog/internal/settings/Settings.java
@@ -10,6 +10,7 @@ import static se.bjurr.gitchangelog.api.GitChangelogApiConstants.DEFAULT_DATEFOR
 import static se.bjurr.gitchangelog.api.GitChangelogApiConstants.DEFAULT_FILE;
 import static se.bjurr.gitchangelog.api.GitChangelogApiConstants.DEFAULT_GITHUB_ISSUE_PATTERN;
 import static se.bjurr.gitchangelog.api.GitChangelogApiConstants.DEFAULT_GITLAB_ISSUE_PATTERN;
+import static se.bjurr.gitchangelog.api.GitChangelogApiConstants.DEFAULT_IGNORE_COMMITS_DATE;
 import static se.bjurr.gitchangelog.api.GitChangelogApiConstants.DEFAULT_IGNORE_COMMITS_REGEXP;
 import static se.bjurr.gitchangelog.api.GitChangelogApiConstants.DEFAULT_JIRA_ISSUE_PATTEN;
 import static se.bjurr.gitchangelog.api.GitChangelogApiConstants.DEFAULT_NO_ISSUE_NAME;
@@ -71,6 +72,13 @@ public class Settings implements Serializable {
    * </code>
    */
   private String ignoreCommitsIfMessageMatches;
+  /**
+   * A date in the format given by {@link Changelog#setDateFormat()} that is evaluated on the author
+   * date of each commit. If the commit is older than the point in time given, then it will be
+   * filtered out and not included in the changelog. <br>
+   * See {@link SimpleDateFormat}.
+   */
+  private String ignoreCommitsIfOlderThan;
   /**
    * Some commits may not be included in any tag. Commits that not released yet may not be tagged.
    * This is a "virtual tag", added to {@link Changelog#getTags()}, that includes those commits. A
@@ -201,6 +209,10 @@ public class Settings implements Serializable {
     this.ignoreTagsIfNameMatches = ignoreTagsIfNameMatches;
   }
 
+  public void setIgnoreCommitsIfOlderThan(String ignoreCommitsIfOlderThan) {
+    this.ignoreCommitsIfOlderThan = ignoreCommitsIfOlderThan;
+  }
+
   public void setJiraIssuePattern(String jiraIssuePattern) {
     this.jiraIssuePattern = jiraIssuePattern;
   }
@@ -222,6 +234,10 @@ public class Settings implements Serializable {
 
   public String getIgnoreCommitsIfMessageMatches() {
     return fromNullable(ignoreCommitsIfMessageMatches).or(DEFAULT_IGNORE_COMMITS_REGEXP);
+  }
+
+  public String getIgnoreCommitsIfOlderThan() {
+    return fromNullable(ignoreCommitsIfOlderThan).or(DEFAULT_IGNORE_COMMITS_DATE);
   }
 
   public String getJiraIssuePattern() {

--- a/src/test/java/se/bjurr/gitchangelog/internal/model/CommitFilterTest.java
+++ b/src/test/java/se/bjurr/gitchangelog/internal/model/CommitFilterTest.java
@@ -1,0 +1,93 @@
+package se.bjurr.gitchangelog.internal.model;
+
+import static com.google.common.collect.Lists.newArrayList;
+import static com.google.common.io.Resources.getResource;
+import static org.assertj.core.api.Assertions.assertThat;
+import static se.bjurr.gitchangelog.api.GitChangelogApiConstants.ZERO_COMMIT;
+
+import com.google.common.base.Optional;
+import com.google.common.io.Resources;
+import java.io.File;
+import java.util.List;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import se.bjurr.gitchangelog.api.model.Commit;
+import se.bjurr.gitchangelog.internal.git.GitRepo;
+import se.bjurr.gitchangelog.internal.git.model.GitCommit;
+import se.bjurr.gitchangelog.internal.settings.Settings;
+
+public class CommitFilterTest {
+  private static final String LATEST_COMMIT_HASH = "0fc7cacfdf677dcb25f0ba5996f2906f69b0ccac";
+
+  private static final String TEST_COMMIT_MESSAGE_PATTERN = "^\\[Gradle Release Plugin\\].*$";
+  private static final String MATCHING_COMMIT_1_HASH = "921b472b2db9b39ed5e6c63c6f5ca4bd80df8eb5";
+  private static final String MATCHING_COMMIT_2_HASH = "2cd70e03b7e2d5af63a9428d78d0ddcfaffde7e3";
+  private static final String NONMATCHING_COMMIT_HASH = "92fca3cfbb690aee22a9d6909cf0f823b878ebbf";
+
+  private static final String DATE_BEGIN_2017 = "2017-01-01 00:00:00";
+  private static final String LATEST_2016_COMMIT_HASH = "4c554557c16f68d27214956db3280492c2bd53dc";
+  private static final String FIRST_2017_COMMIT_HASH = "e569b0c8dfe5957c3552ea241a21033b24ad1d97";
+  private static final String A_2017_COMMIT_HASH_MATCHING_MESSAGE_PATTERN =
+      "4f8d3e3c7bcc24f53aff2ebf696a2eaab5217126";
+  private GitRepo gitRepo;
+  private List<GitCommit> commits;
+  private Settings settings;
+
+  @Before
+  public void before() throws Exception {
+    gitRepo = new GitRepo(new File(Resources.getResource("github-issues.json").getFile()));
+    commits =
+        newArrayList(
+            gitRepo
+                .getGitRepoData(
+                    gitRepo.getCommit(ZERO_COMMIT),
+                    gitRepo.getCommit(LATEST_COMMIT_HASH),
+                    null,
+                    Optional.of(""))
+                .getGitCommits());
+    settings =
+        Settings.fromFile(getResource("settings/git-changelog-test-settings.json").toURI().toURL());
+  }
+
+  @Test
+  public void testThatFilterWithIgnoreCommitsWithMessageWorks() throws Exception {
+    settings.setIgnoreCommitsIfMessageMatches(TEST_COMMIT_MESSAGE_PATTERN);
+    List<String> transformedCommits = hashes((new Transformer(settings)).toCommits(commits));
+    assertThat(transformedCommits).contains(NONMATCHING_COMMIT_HASH);
+    assertThat(transformedCommits).doesNotContain(MATCHING_COMMIT_1_HASH, MATCHING_COMMIT_2_HASH);
+  }
+
+  @Test
+  public void testThatFilterWithIgnoreCommitsOlderThanWorks() throws Exception {
+    settings.setIgnoreCommitsIfMessageMatches("");
+    settings.setIgnoreCommitsIfOlderThan(DATE_BEGIN_2017);
+    List<String> transformedCommits = hashes((new Transformer(settings)).toCommits(commits));
+    assertThat(transformedCommits).doesNotContain(LATEST_2016_COMMIT_HASH);
+    assertThat(transformedCommits)
+        .contains(FIRST_2017_COMMIT_HASH, A_2017_COMMIT_HASH_MATCHING_MESSAGE_PATTERN);
+  }
+
+  @Test
+  public void testThatFilterWithIgnoreCommitsWithMessageAndOlderThanWorks() throws Exception {
+    settings.setIgnoreCommitsIfOlderThan(DATE_BEGIN_2017);
+    settings.setIgnoreCommitsIfMessageMatches(TEST_COMMIT_MESSAGE_PATTERN);
+    List<String> transformedCommits = hashes((new Transformer(settings)).toCommits(commits));
+    assertThat(transformedCommits).contains(FIRST_2017_COMMIT_HASH);
+    assertThat(transformedCommits)
+        .doesNotContain(LATEST_2016_COMMIT_HASH, A_2017_COMMIT_HASH_MATCHING_MESSAGE_PATTERN);
+  }
+
+  @After
+  public void after() throws Exception {
+    gitRepo.close();
+  }
+
+  private List<String> hashes(List<Commit> commits) {
+    List<String> hashes = newArrayList();
+    for (Commit c : commits) {
+      hashes.add(c.getHashFull());
+    }
+    return hashes;
+  }
+}


### PR DESCRIPTION
I would like to be able to see only commits with a limited age (or commits after some date).

This pull request implements a new setting that goes along the line of _ignoreCommitsIfMessageMatches_:
 _ignoreCommitsIfOlderThan_.

`settings:`
```yaml
{
    # ...
    "dateFormat": "YYYY-MM-dd HH:mm:ss",
    "ignoreCommitsIfOlderThan": "2017-01-01 00:00:00",
    # ...
}
```

The rationale is that perhaps projects might:
* use a git-based changelog to inform coworkers, rather than customers, making a more short-lived "news"-style log desirable, _(this is our use-case)_
* not (yet?) use frequent-enough tags in their repository, _(also true where I work)_
* want to provide a sense for the liveliness of a project

There are tests.

What do you guys think? Any suggestions? Anything I have overlooked, or that should be improved? Would be very happy to see this merged. :smile:

One point of critique could be that I coupled the date format of `ignoreCommitsIfOlderThan` to the quite unrelated `dateFormat`, but it does eliminate the need for an extra setting. Alternatively one could think about simply mandating a specific format like `YYYY-MM-dd HH:mm:ss` or so, ignoring `dateFormat`.