### PR TITLE
Fix CommitsWithMesssage typo -> CommitsWithMessage

### DIFF
--- a/src/main/java/se/bjurr/gitchangelog/api/GitChangelogApi.java
+++ b/src/main/java/se/bjurr/gitchangelog/api/GitChangelogApi.java
@@ -245,7 +245,7 @@ public class GitChangelogApi {
    * ^\\[maven-release-plugin\\].*|^\\[Gradle Release Plugin\\].*|^Merge.*
    * </code>
    */
-  public GitChangelogApi withIgnoreCommitsWithMesssage(String ignoreCommitsIfMessageMatches) {
+  public GitChangelogApi withIgnoreCommitsWithMessage(String ignoreCommitsIfMessageMatches) {
     this.settings.setIgnoreCommitsIfMessageMatches(ignoreCommitsIfMessageMatches);
     return this;
   }

--- a/src/test/java/se/bjurr/gitchangelog/api/GitChangelogApiAsserter.java
+++ b/src/test/java/se/bjurr/gitchangelog/api/GitChangelogApiAsserter.java
@@ -40,7 +40,7 @@ public class GitChangelogApiAsserter {
 
     if (this.ignoreCommitsIfMessageMatches != null) {
       gitChangelogApiBuilder //
-          .withIgnoreCommitsWithMesssage(this.ignoreCommitsIfMessageMatches);
+          .withIgnoreCommitsWithMessage(this.ignoreCommitsIfMessageMatches);
     }
 
     String changelog = toJson(gitChangelogApiBuilder.getChangelog());
@@ -67,7 +67,7 @@ public class GitChangelogApiAsserter {
             .withFromRepo(".") //
             .withFromCommit(ZERO_COMMIT) //
             .withToRef("test") //
-            .withIgnoreCommitsWithMesssage(
+            .withIgnoreCommitsWithMessage(
                 "^\\[maven-release-plugin\\].*|^\\[Gradle Release Plugin\\].*|^Merge.*") //
             .withIgnoreTagsIfNameMatches(".*tag-in-test-feature$") //
             .withReadableTagName("/([^/]+?)$") //
@@ -91,7 +91,7 @@ public class GitChangelogApiAsserter {
 
     if (this.ignoreCommitsIfMessageMatches != null) {
       withTemplatePath //
-          .withIgnoreCommitsWithMesssage(this.ignoreCommitsIfMessageMatches);
+          .withIgnoreCommitsWithMessage(this.ignoreCommitsIfMessageMatches);
     }
 
     assertEquals(

--- a/src/test/java/se/bjurr/gitchangelog/api/GitChangelogApiTest.java
+++ b/src/test/java/se/bjurr/gitchangelog/api/GitChangelogApiTest.java
@@ -62,7 +62,7 @@ public class GitChangelogApiTest {
                 .withFromCommit(ZERO_COMMIT) //
                 .withToRef("test") //
                 .withTemplatePath(templatePath) //
-                .withIgnoreCommitsWithMesssage(".*") //
+                .withIgnoreCommitsWithMessage(".*") //
                 .render() //
                 .trim())
         .hasSize(74);


### PR DESCRIPTION
Typo. One **s** too many.