### PR TITLE
changelog.json: Fix invalid JSON

### DIFF
--- a/changelog.json
+++ b/changelog.json
@@ -24,8 +24,8 @@
  "gitLabProjectName": "",
 
  "customIssues": [
-  { "name": "Incidents", title: "${PATTERN_GROUP_1}", "pattern": "INC([0-9]*)", "link": "http://inc/${PATTERN_GROUP}" },
-  { "name": "CQ", title: "${PATTERN_GROUP_1}", "pattern": "CQ([0-9]+)", "link": "http://cq/${PATTERN_GROUP_1}" },
-  { "name": "Bugs", title: "Mixed bugs", "pattern": "#bug" }
+  { "name": "Incidents", "title": "${PATTERN_GROUP_1}", "pattern": "INC([0-9]*)", "link": "http://inc/${PATTERN_GROUP}" },
+  { "name": "CQ", "title": "${PATTERN_GROUP_1}", "pattern": "CQ([0-9]+)", "link": "http://cq/${PATTERN_GROUP_1}" },
+  { "name": "Bugs", "title": "Mixed bugs", "pattern": "#bug" }
  ]
 }


### PR DESCRIPTION
I imagine most JSON parsers will just treat this as a warning and move on, but some might be strict enough to barf on it :)