### PR TITLE
upgrade gitlab dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,7 @@ dependencies {
  compile 'com.google.guava:guava:16.0.1'
  compile 'org.eclipse.jgit:org.eclipse.jgit:3.6.2.201501210735-r'
  compile 'com.github.spullara.mustache.java:compiler:0.8.18'
- compile 'org.gitlab:java-gitlab-api:1.2.7'
+ compile 'org.gitlab:java-gitlab-api:4.1.0'
  testCompile 'junit:junit:4.12'
  testCompile 'org.slf4j:slf4j-simple:1.7.13'
  testCompile 'org.assertj:assertj-core:2.3.0'


### PR DESCRIPTION
Gitlab v3 has been deprecated (see https://about.gitlab.com/2018/06/01/api-v3-removal-impending/) and a new version was released.