### PR TITLE
Add an option to filter the commits using a path filter string

### DIFF
--- a/src/main/java/se/bjurr/gitchangelog/api/GitChangelogApi.java
+++ b/src/main/java/se/bjurr/gitchangelog/api/GitChangelogApi.java
@@ -429,6 +429,15 @@ public class GitChangelogApi {
   }
 
   /**
+   * Filter commits using the provided path filter, analogous to using the cli command git log --
+   * 'pathFilter'
+   */
+  public GitChangelogApi withPathFilter(final String pathFilter) {
+    this.settings.setPathFilter(pathFilter);
+    return this;
+  }
+
+  /**
    * Some commits may not be included in any tag. Commits that not released yet may not be tagged.
    * This is a "virtual tag", added to {@link Changelog#getTags()}, that includes those commits. A
    * fitting value may be "Next release".
@@ -440,6 +449,7 @@ public class GitChangelogApi {
 
   private Changelog getChangelog(final GitRepo gitRepo, final boolean useIntegrationIfConfigured)
       throws GitChangelogRepositoryException {
+    gitRepo.setTreeFilter(settings.getSubDirFilter());
     final ObjectId fromId =
         getId(gitRepo, this.settings.getFromRef(), this.settings.getFromCommit()) //
             .or(gitRepo.getCommit(ZERO_COMMIT));

--- a/src/main/java/se/bjurr/gitchangelog/internal/settings/Settings.java
+++ b/src/main/java/se/bjurr/gitchangelog/internal/settings/Settings.java
@@ -181,6 +181,16 @@ public class Settings implements Serializable {
    */
   private String gitLabProjectName;
 
+  public String getSubDirFilter() {
+    return fromNullable(subDirFilter).or("");
+  }
+
+  public void setPathFilter(String subDirFilter) {
+    this.subDirFilter = subDirFilter;
+  }
+
+  private String subDirFilter;
+
   public Settings() {}
 
   public void setCustomIssues(final List<SettingsIssue> customIssues) {

--- a/src/test/java/se/bjurr/gitchangelog/api/GitChangelogApiTest.java
+++ b/src/test/java/se/bjurr/gitchangelog/api/GitChangelogApiTest.java
@@ -75,6 +75,21 @@ public class GitChangelogApiTest {
   }
 
   @Test
+  public void testPathFilterCanBeSpecified() throws Exception {
+    final String templatePath = "templatetest/testAuthorsCommitsExtended.mustache";
+
+    assertThat(
+            gitChangelogApiBuilder() //
+                .withFromCommit(ZERO_COMMIT) //
+                .withToRef("1.71") //
+                .withTemplatePath(templatePath) //
+                .withPathFilter("src") //
+                .render() //
+                .trim())
+        .hasSize(168);
+  }
+
+  @Test
   public void testThatIssuesCanBeRemoved() throws Exception {
 
     final String expected =

--- a/src/test/java/se/bjurr/gitchangelog/internal/git/GitRepoTest.java
+++ b/src/test/java/se/bjurr/gitchangelog/internal/git/GitRepoTest.java
@@ -270,6 +270,26 @@ public class GitRepoTest {
     assertThat(firstCommit.name()).as(gitRepo.toString()).startsWith(FIRST_COMMIT_HASH);
   }
 
+  @Test
+  public void testThatRepoFilterReducesTheNumberOfCommits() throws Exception {
+    GitRepo gitRepo = getGitRepo();
+    gitRepo.setTreeFilter("src/");
+    ObjectId firstCommit = gitRepo.getCommit(ZERO_COMMIT);
+    ObjectId lastCommit = gitRepo.getRef("1.71");
+
+    GitRepoData gitRepoData =
+        gitRepo.getGitRepoData(
+            firstCommit, lastCommit, "No tag", Optional.of(".*tag-in-test-feature$"));
+
+    List<GitCommit> gitCommits = gitRepoData.getGitCommits();
+    assertThat(gitCommits)
+        .as("Commits in first release.") //
+        .hasSize(104);
+
+    assertThat(gitCommits.get(0).getHash()).startsWith("a394e04");
+    assertThat(reverse(gitCommits).get(0).getHash()).startsWith("5aaeb907");
+  }
+
   private GitRepo getGitRepo() throws Exception {
     return new GitRepo(this.gitRepoFile);
   }


### PR DESCRIPTION
This works like `git log -- path`. It allows us to generate an independent changelog for each subdirectory of a repository.
 
Our use case is adding a changelog for independently packaged plugins that live in the same git repository and are build with a maven multi-module build. We only want commits to be added to the changelog of plugins that are affected by a change to (maintain reproducible builds). I am happy to discuss how to improve this. 

This PR adds support for this in maven plugin: https://github.com/tomasbjerre/git-changelog-maven-plugin/pull/19
