### PR TITLE
Added possibility to filter JIRA request also by additional fields

### DIFF
--- a/src/main/java/se/bjurr/gitchangelog/api/GitChangelogApi.java
+++ b/src/main/java/se/bjurr/gitchangelog/api/GitChangelogApi.java
@@ -370,6 +370,12 @@ public class GitChangelogApi {
     return this;
   }
 
+  /** Additional Filter Fields for Jira. */
+  public GitChangelogApi withJiraIssueFieldsFilter(Map map) {
+    this.settings.setJiraIssueFieldsFilter(map);
+    return this;
+  }
+
   /**
    * This is a "virtual issue" that is added to {@link Changelog#getIssues()}. It contains all
    * commits that has no issue in the commit comment. This could be used as a "wall of shame"

--- a/src/main/java/se/bjurr/gitchangelog/internal/integrations/jira/DefaultJiraClient.java
+++ b/src/main/java/se/bjurr/gitchangelog/internal/integrations/jira/DefaultJiraClient.java
@@ -46,4 +46,8 @@ public class DefaultJiraClient extends JiraClient {
     }
     return absent();
   }
+
+  public JiraClient withAdditionalFields(Map<String, String> fields) {
+    return this;
+  }
 }

--- a/src/main/java/se/bjurr/gitchangelog/internal/integrations/jira/JiraClient.java
+++ b/src/main/java/se/bjurr/gitchangelog/internal/integrations/jira/JiraClient.java
@@ -57,6 +57,8 @@ public abstract class JiraClient {
 
   public abstract JiraClient withHeaders(Map<String, String> headers);
 
+  public abstract JiraClient withAdditionalFields(Map<String, String> fields);
+
   public abstract Optional<JiraIssue> getIssue(String matched)
       throws GitChangelogIntegrationException;
 }

--- a/src/main/java/se/bjurr/gitchangelog/internal/integrations/jira/JiraClientFactory.java
+++ b/src/main/java/se/bjurr/gitchangelog/internal/integrations/jira/JiraClientFactory.java
@@ -1,5 +1,7 @@
 package se.bjurr.gitchangelog.internal.integrations.jira;
 
+import se.bjurr.gitchangelog.internal.settings.Settings;
+
 public class JiraClientFactory {
 
   private static JiraClient jiraClient;
@@ -13,10 +15,14 @@ public class JiraClientFactory {
     JiraClientFactory.jiraClient = jiraClient;
   }
 
-  public static JiraClient createJiraClient(final String apiUrl) {
+  public static JiraClient createJiraClient(Settings settings) {
     if (jiraClient != null) {
       return jiraClient;
     }
-    return new DefaultJiraClient(apiUrl);
+    if (!settings.getJiraIssueFieldsFilter().isEmpty()) {
+      return new JqlSearchJiraClient(settings.getJiraServer().get());
+    } else {
+      return new DefaultJiraClient(settings.getJiraServer().get());
+    }
   }
 }

--- a/src/main/java/se/bjurr/gitchangelog/internal/integrations/jira/JqlSearchJiraClient.java
+++ b/src/main/java/se/bjurr/gitchangelog/internal/integrations/jira/JqlSearchJiraClient.java
@@ -1,0 +1,109 @@
+package se.bjurr.gitchangelog.internal.integrations.jira;
+
+import static com.google.common.base.Optional.absent;
+import static com.google.common.base.Optional.fromNullable;
+import static com.jayway.jsonpath.JsonPath.read;
+import static java.util.concurrent.TimeUnit.MINUTES;
+
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import com.google.common.base.Optional;
+import com.jayway.jsonpath.JsonPath;
+import com.jayway.jsonpath.PathNotFoundException;
+
+import se.bjurr.gitchangelog.api.exceptions.GitChangelogIntegrationException;
+import se.bjurr.gitchangelog.internal.integrations.rest.RestClient;
+
+public class JqlSearchJiraClient extends JiraClient {
+
+    private RestClient client;
+    private Map<String, String> fieldMap;
+
+    public JqlSearchJiraClient(String api) {
+        super(api);
+        this.client = new RestClient(1, MINUTES);
+    }
+
+    protected JiraIssue toJiraIssue(String issue, String json) {
+        try {
+            String title = read(json, "$.issues[0].fields.summary");
+            String description = read(json, "$.issues[0].fields.description");
+            String type = read(json, "$.issues[0].fields.issuetype.name");
+            String link = getApi() + "/browse/" + issue;
+            List<String> labels = JsonPath.read(json, "$.issues[0].fields.labels");
+            List<String> linkedIssues = new ArrayList<>();
+            List<String> inwardKey = JsonPath.read(json, "$.issues[0].fields.issuelinks[*].inwardIssue.key");
+            List<String> outwardKey = JsonPath.read(json, "$.issues[0].fields.issuelinks[*].outwardIssue.key");
+            linkedIssues.addAll(inwardKey);
+            linkedIssues.addAll(outwardKey);
+
+            JiraIssue jiraIssue = new JiraIssue(title, description, link, issue, type, linkedIssues, labels);
+            return jiraIssue;
+        } catch (PathNotFoundException e) {
+            return null;
+        }
+    }
+
+    @Override
+    public JiraClient withBasicCredentials(String username, String password) {
+        this.client = client.withBasicAuthCredentials(username, password);
+        return this;
+    }
+
+    @Override
+    public JiraClient withTokenCredentials(String token) {
+        this.client = client.withTokenAuthCredentials(token);
+        return this;
+    }
+
+    @Override
+    public JiraClient withHeaders(Map<String, String> headers) {
+        this.client = client.withHeaders(headers);
+        return this;
+    }
+
+    public JiraClient withAdditionalFields(Map<String, String> fields) {
+        this.fieldMap = fields;
+        return this;
+    }
+
+    @Override
+    public Optional<JiraIssue> getIssue(String issue) throws GitChangelogIntegrationException {
+        String endpoint = getEndpoint(issue);
+        Optional<String> json = client.get(endpoint);
+        if (json.isPresent()) {
+            JiraIssue jiraIssue = toJiraIssue(issue, json.get());
+            return fromNullable(jiraIssue);
+        }
+        return absent();
+    }
+
+    protected String getEndpoint(String issue) {
+        String endpoint = getApi()
+                + "/rest/api/2/search?jql=issue="
+                + issue
+                + (hasAdditionalFields() ? getAdditionalFieldsQuery() : "")
+                + "&fields=parent,summary,issuetype,labels,description,issuelinks";
+        return endpoint;
+    }
+
+    private boolean hasAdditionalFields() {
+        return !fieldMap.isEmpty();
+    }
+
+    private String getAdditionalFieldsQuery() {
+        String query = "";
+        for (Map.Entry<String, String> field : fieldMap.entrySet()) {
+            query += " AND " + field.getKey() + "='" + field.getValue() + "'";
+        }
+        try {
+            return URLEncoder.encode(query, "UTF-8");
+        } catch (UnsupportedEncodingException e) {
+            return query;
+        }
+    }
+}

--- a/src/main/java/se/bjurr/gitchangelog/internal/issues/IssueParser.java
+++ b/src/main/java/se/bjurr/gitchangelog/internal/issues/IssueParser.java
@@ -169,7 +169,7 @@ public class IssueParser {
   private JiraClient createJiraClient() {
     JiraClient jiraClient = null;
     if (settings.getJiraServer().isPresent()) {
-      jiraClient = JiraClientFactory.createJiraClient(settings.getJiraServer().get());
+      jiraClient = JiraClientFactory.createJiraClient(settings);
       if (settings.getJiraUsername().isPresent()) {
         jiraClient.withBasicCredentials(
             settings.getJiraUsername().get(), settings.getJiraPassword().get());
@@ -178,6 +178,9 @@ public class IssueParser {
       }
       if (settings.getExtendedRestHeaders() != null) {
         jiraClient.withHeaders(settings.getExtendedRestHeaders());
+      }
+      if (settings.getJiraIssueFieldsFilter() != null && !settings.getJiraIssueFieldsFilter().isEmpty()) {
+        jiraClient.withAdditionalFields(settings.getJiraIssueFieldsFilter());
       }
     }
     return jiraClient;

--- a/src/main/java/se/bjurr/gitchangelog/internal/settings/Settings.java
+++ b/src/main/java/se/bjurr/gitchangelog/internal/settings/Settings.java
@@ -127,6 +127,11 @@ public class Settings implements Serializable {
    * <code>\\b[a-zA-Z]([a-zA-Z]+)-([0-9]+)\\b</code>
    */
   private String jiraIssuePattern;
+  /**
+   * Additional fields to filter the issues.<br>
+   * if this is used, Jira's search-API is used instead of issues-API <br>
+   */
+  private Map<String, String> jiraIssueFieldsFilter = new HashMap<>();
   /** Authenticate to JIRA. */
   private String jiraUsername;
   /** Authenticate to JIRA. */
@@ -481,5 +486,13 @@ public class Settings implements Serializable {
 
   public Optional<String> getGitLabProjectName() {
     return fromNullable(gitLabProjectName);
+  }
+
+  public Map<String, String> getJiraIssueFieldsFilter() {
+    return jiraIssueFieldsFilter;
+  }
+
+  public void setJiraIssueFieldsFilter(Map<String, String> jiraIssueFieldsFilter) {
+    this.jiraIssueFieldsFilter = jiraIssueFieldsFilter;
   }
 }

--- a/src/test/java/se/bjurr/gitchangelog/internal/integrations/jira/JiraClientTest.java
+++ b/src/test/java/se/bjurr/gitchangelog/internal/integrations/jira/JiraClientTest.java
@@ -45,6 +45,11 @@ public class JiraClientTest {
       public Optional<JiraIssue> getIssue(String matched) throws GitChangelogIntegrationException {
         return null;
       }
+
+      @Override
+      public JiraClient withAdditionalFields(Map<String, String> fields) {
+          return null;
+      }
     };
   }
 }


### PR DESCRIPTION
…and customfields. Instead of using the issues API, it will use a jql search instead.
This feature is needed, if you develop for e.g. multiple clients in one branch and in one Jira project, but each client should only see the commits that  belong to him. So you can define a custom field and integrate this into the plugin configuration and filter out all other tickets that are of no interest.
Instead of using the issues api, this will use the Jira search api and create an jql query
