### PR TITLE
feat: Add support for including partials in mustache templates

### DIFF
--- a/src/main/java/se/bjurr/gitchangelog/api/GitChangelogApi.java
+++ b/src/main/java/se/bjurr/gitchangelog/api/GitChangelogApi.java
@@ -12,6 +12,8 @@ import com.github.jknack.handlebars.Context;
 import com.github.jknack.handlebars.Handlebars;
 import com.github.jknack.handlebars.Helper;
 import com.github.jknack.handlebars.Template;
+import com.github.jknack.handlebars.io.FileTemplateLoader;
+
 import java.io.File;
 import java.io.IOException;
 import java.io.StringWriter;
@@ -98,6 +100,11 @@ public class GitChangelogApi {
   public void render(final Writer writer) throws GitChangelogRepositoryException {
     Template template = null;
     final String templateString = this.getTemplateString();
+
+    if (this.settings.getTemplateBaseDir() != null) {
+      this.handlebars.with(new FileTemplateLoader(this.settings.getTemplateBaseDir(), this.settings.getTemplateSuffix()));
+    }
+
     try {
       template = this.handlebars.compileInline(templateString);
     } catch (final IOException e) {
@@ -547,6 +554,22 @@ public class GitChangelogApi {
    */
   public GitChangelogApi withTemplatePath(final String templatePath) {
     this.settings.setTemplatePath(templatePath);
+    return this;
+  }
+
+  /**
+   * Path to the base directory for template partial files
+   */
+  public GitChangelogApi withTemplateBaseDir(final String templateBaseDir) {
+    this.settings.setTemplateBaseDir(templateBaseDir);
+    return this;
+  }
+
+  /**
+   * Suffix of the template partial files
+   */
+  public GitChangelogApi withTemplateSuffix(final String templateSuffix) {
+    this.settings.setTemplateSuffix(templateSuffix);
     return this;
   }
 

--- a/src/main/java/se/bjurr/gitchangelog/internal/settings/Settings.java
+++ b/src/main/java/se/bjurr/gitchangelog/internal/settings/Settings.java
@@ -94,6 +94,15 @@ public class Settings implements Serializable {
    */
   private String templatePath;
   /**
+   * Path to the base directory for template partial files. If not null, handlebars will be
+   * configured with a FileTemplateLoader with this as base directory.
+   */
+  private String templateBaseDir;
+  /**
+   * The filename suffix of template partial files. Requires "templateBaseDir" to be set.
+   */
+  private String templateSuffix;
+  /**
    * Your tags may look something like <code>git-changelog-maven-plugin-1.6</code>. But in the
    * changelog you just want <code>1.6</code>. With this regular expression, the numbering can be
    * extracted from the tag name.<br>
@@ -369,11 +378,27 @@ public class Settings implements Serializable {
     return ofNullable(this.templatePath).orElse("changelog.mustache");
   }
 
-  public void setTemplatePath(final String templatePath) {
+public void setTemplatePath(final String templatePath) {
     this.templatePath = templatePath;
   }
 
-  public String getReadableTagName() {
+public String getTemplateBaseDir() {
+	return templateBaseDir;
+}
+
+public void setTemplateBaseDir(String templateBaseDir) {
+	this.templateBaseDir = templateBaseDir;
+}
+
+  public String getTemplateSuffix() {
+	return templateSuffix;
+}
+
+public void setTemplateSuffix(String templateSuffix) {
+	this.templateSuffix = templateSuffix;
+}
+
+public String getReadableTagName() {
     return ofNullable(this.readableTagName).orElse(DEFAULT_READABLE_TAG_NAME);
   }
 
@@ -411,6 +436,7 @@ public class Settings implements Serializable {
     s.setFromCommit(ZERO_COMMIT);
     s.setToRef("refs/heads/master");
     s.setIgnoreCommitsIfMessageMatches("^Merge.*");
+    s.setTemplateSuffix(".hbs");
     s.setReadableTagName("/([^/]+?)$");
     s.setDateFormat("YYYY-MM-dd HH:mm:ss");
     s.setUntaggedName("No tag");

--- a/src/test/java/se/bjurr/gitchangelog/api/GitChangelogApiTest.java
+++ b/src/test/java/se/bjurr/gitchangelog/api/GitChangelogApiTest.java
@@ -299,4 +299,21 @@ public class GitChangelogApiTest {
     System.out.println(path.toFile().getAbsolutePath());
     assertThat(path.toFile()).exists().isFile();
   }
+
+  @Test
+  public void testThatPartialsCanBeIncluded() throws Exception {
+    final String templatePath = "templatetest/testThatPartialsCanBeIncluded.mustache";
+
+    final Path path = Paths.get("build", "testdirtocreate", "testThatPartialsCanBeIncluded.md");
+    gitChangelogApiBuilder() //
+        .withFromCommit("aa1fd33") //
+        .withToCommit("4c6e078") //
+        .withTemplatePath(templatePath) //
+        .withTemplateBaseDir("./src/test/resources/templatetest") //
+        .withTemplateSuffix(".partial") //
+        .toFile(path.toFile());
+
+    System.out.println(path.toFile().getAbsolutePath());
+    assertThat(path.toFile()).exists().isFile();
+  }
 }

--- a/src/test/resources/templatetest/commit.partial
+++ b/src/test/resources/templatetest/commit.partial
@@ -1,0 +1,4 @@
+## {{authorName}} - {{commitTime}}
+[{{hashFull}}](https://server/{{hash}})
+
+{{{message}}}

--- a/src/test/resources/templatetest/testThatPartialsCanBeIncluded.mustache
+++ b/src/test/resources/templatetest/testThatPartialsCanBeIncluded.mustache
@@ -1,0 +1,7 @@
+# Git Changelog changelog
+
+Changelog of Git Changelog.
+
+{{#commits}}
+{{> commit}}
+{{/commits}}


### PR DESCRIPTION
This PR adds support for template partials (<http://jknack.github.io/handlebars.java/reuse.html>).

Two new settings are introduced:

- `templateBaseDir`: points to the directory that contains the partials
- `templateSuffix`: the filename suffix of the partials (defaults to `.hbs`)

If the setting `templateBaseDir` is not null, a `FileTemplateLoader` is
used instead of the default `ClassPathTemplateLoader`.

In my changelog I have the different sections for the different types of commits (fix, feat, ...). I now want to be able to define how a commit is printed once instead of duplicating it in every section. Using partials is the way I found to solve this.

Partials also would allow to include content generated outside of gitchangeloglib. I have in mind to do a diff of a properties file in my CI pipeline and write it to a file. I want then to include this diff in the changelog.

Let me know what you think of this feature.