### PR TITLE
feat: Add support for defining Javascript helpers in a separate file

### DIFF
--- a/src/main/java/se/bjurr/gitchangelog/api/GitChangelogApi.java
+++ b/src/main/java/se/bjurr/gitchangelog/api/GitChangelogApi.java
@@ -241,6 +241,17 @@ public class GitChangelogApi {
   }
 
   /**
+   * Registers (Javscript) Handlebars helper file to use in template.
+   *
+   * @see https://github.com/jknack/handlebars.java/tree/master#with-plain-javascript
+   */
+  public GitChangelogApi withHandlebarsHelperFile(final String javascriptHelperFile)
+      throws GitChangelogRepositoryException, IOException {
+    String javascriptHelper = ResourceLoader.getResourceOrFile(javascriptHelperFile);
+    return this.withHandlebarsHelper(javascriptHelper);
+  }
+
+  /**
    * Registers (Javscript) Handlebars helper to use in template.
    *
    * @see https://github.com/jknack/handlebars.java/tree/master#with-plain-javascript

--- a/src/test/java/se/bjurr/gitchangelog/api/helpers/HandlebarsHelperTest.java
+++ b/src/test/java/se/bjurr/gitchangelog/api/helpers/HandlebarsHelperTest.java
@@ -20,6 +20,17 @@ public class HandlebarsHelperTest {
   }
 
   @Test
+  public void testThatHelperCanBeSuppliedWithJavascriptFile() throws Exception {
+    final GitChangelogApi given =
+        this.baseBuilder //
+            .withTemplatePath(
+                "templatetest/helpers/testThatHelperCanBeSuppliedWithJavascript.mustache")
+            .withHandlebarsHelperFile("templatetest/helpers/helper.js");
+
+    ApprovalsWrapper.verify(given);
+  }
+
+  @Test
   public void testThatHelperCanBeSuppliedWithJavascript() throws Exception {
     final GitChangelogApi given =
         this.baseBuilder //

--- a/src/test/java/se/bjurr/gitchangelog/api/helpers/HandlebarsHelperTest.testThatHelperCanBeSuppliedWithJavascriptFile.approved.txt
+++ b/src/test/java/se/bjurr/gitchangelog/api/helpers/HandlebarsHelperTest.testThatHelperCanBeSuppliedWithJavascriptFile.approved.txt
@@ -1,0 +1,1611 @@
+template:
+
+{{#commits}}
+  First word: {{#firstWord}}{{message}}{{/firstWord}}
+
+  All of message:
+
+  {{message}}
+--------------------------------
+
+
+{{/commits}}
+
+---------------------------------------------
+
+settings:
+
+{
+  "fromRepo": ".",
+  "fromCommit": "1edc0d7",
+  "toCommit": "e78a62f",
+  "templatePath": "templatetest/helpers/testThatHelperCanBeSuppliedWithJavascript.mustache",
+  "removeIssueFromMessage": false,
+  "gitHubApi": "https://api.github.com/repos/tomasbjerre/git-changelog-lib",
+  "extendedVariables": {},
+  "ignoreCommitsWithoutIssue": false,
+  "gitLabProjectName": "tomasbjerre"
+}
+
+---------------------------------------------
+
+changelog:
+
+  First word: [Gradle
+
+  All of message:
+
+  [Gradle Release Plugin] - new version commit:  &#x27;1.97-SNAPSHOT&#x27;.
+--------------------------------
+
+
+  First word: [Gradle
+
+  All of message:
+
+  [Gradle Release Plugin] - pre tag commit:  &#x27;1.96&#x27;.
+--------------------------------
+
+
+  First word: pretty
+
+  All of message:
+
+  pretty printing output JENKINS-65252
+--------------------------------
+
+
+  First word: [Gradle
+
+  All of message:
+
+  [Gradle Release Plugin] - new version commit:  &#x27;1.96-SNAPSHOT&#x27;.
+--------------------------------
+
+
+  First word: [Gradle
+
+  All of message:
+
+  [Gradle Release Plugin] - pre tag commit:  &#x27;1.95&#x27;.
+--------------------------------
+
+
+  First word: Removing
+
+  All of message:
+
+  Removing default ignore filter on message
+
+It was: &#x60;^\[maven-release-plugin\].*|^\[Gradle Release Plugin\].*|^Merge.*&quot;&#x60;
+
+But users are confused by this and it is probably better to have no filter by default.
+--------------------------------
+
+
+  First word: Switching
+
+  All of message:
+
+  Switching to Handlebars from Mustache
+
+ * Removing Mediawiki support. Because I have not been able to make it work. https://stackoverflow.com/questions/45779754/cannot-authenticate-with-mediawiki-1-28-api
+ * Steeping up JGit to latest release. 3.6.2.201501210735-r to 5.10.0.202012080955-r.
+ * Refactoring tests to use Approvals.
+--------------------------------
+
+
+  First word: [Gradle
+
+  All of message:
+
+  [Gradle Release Plugin] - new version commit:  &#x27;1.95-SNAPSHOT&#x27;.
+--------------------------------
+
+
+
+
+---------------------------------------------
+
+context:
+
+{
+  "commits": [
+    {
+      "authorEmailAddress": "tomas.bjerre85@gmail.com",
+      "authorName": "Tomas Bjerre",
+      "commitTime": "2021-03-29 15:35:07",
+      "commitTimeLong": 1617032107000,
+      "hash": "e78a62ffbb9b57c",
+      "hashFull": "e78a62ffbb9b57cf2b274bab18c7b65eadaf6015",
+      "merge": false,
+      "message": "[Gradle Release Plugin] - new version commit:  \u00271.97-SNAPSHOT\u0027."
+    },
+    {
+      "authorEmailAddress": "tomas.bjerre85@gmail.com",
+      "authorName": "Tomas Bjerre",
+      "commitTime": "2021-03-29 15:34:15",
+      "commitTimeLong": 1617032055000,
+      "hash": "81936b9d6d9bbb8",
+      "hashFull": "81936b9d6d9bbb84ff860e4e08e132a13909ea16",
+      "merge": false,
+      "message": "[Gradle Release Plugin] - pre tag commit:  \u00271.96\u0027."
+    },
+    {
+      "authorEmailAddress": "tomas.bjerre85@gmail.com",
+      "authorName": "Tomas Bjerre",
+      "commitTime": "2021-03-29 15:33:00",
+      "commitTimeLong": 1617031980000,
+      "hash": "bea18ab90db148c",
+      "hashFull": "bea18ab90db148c3f9a90078424bd6ea36dd5108",
+      "merge": false,
+      "message": "pretty printing output JENKINS-65252"
+    },
+    {
+      "authorEmailAddress": "tomas.bjerre85@gmail.com",
+      "authorName": "Tomas Bjerre",
+      "commitTime": "2021-01-18 16:49:30",
+      "commitTimeLong": 1610988570000,
+      "hash": "8cda1f4c79c8891",
+      "hashFull": "8cda1f4c79c8891510fa81fbb65e6955d4337e33",
+      "merge": false,
+      "message": "[Gradle Release Plugin] - new version commit:  \u00271.96-SNAPSHOT\u0027."
+    },
+    {
+      "authorEmailAddress": "tomas.bjerre85@gmail.com",
+      "authorName": "Tomas Bjerre",
+      "commitTime": "2021-01-18 16:48:34",
+      "commitTimeLong": 1610988514000,
+      "hash": "da85629f0a0d922",
+      "hashFull": "da85629f0a0d92298c2be0193324a0bc2281f929",
+      "merge": false,
+      "message": "[Gradle Release Plugin] - pre tag commit:  \u00271.95\u0027."
+    },
+    {
+      "authorEmailAddress": "tomas.bjerre85@gmail.com",
+      "authorName": "Tomas Bjerre",
+      "commitTime": "2021-01-18 16:46:13",
+      "commitTimeLong": 1610988373000,
+      "hash": "a57e321f08cea10",
+      "hashFull": "a57e321f08cea10843cc8c7d1c41a1d03318e8d6",
+      "merge": false,
+      "message": "Removing default ignore filter on message\n\nIt was: `^\\[maven-release-plugin\\].*|^\\[Gradle Release Plugin\\].*|^Merge.*\"`\n\nBut users are confused by this and it is probably better to have no filter by default."
+    },
+    {
+      "authorEmailAddress": "tomas.bjerre85@gmail.com",
+      "authorName": "Tomas Bjerre",
+      "commitTime": "2020-12-24 07:11:41",
+      "commitTimeLong": 1608793901000,
+      "hash": "7eba3d038b884b8",
+      "hashFull": "7eba3d038b884b845644c202f6a98632d52fbb9e",
+      "merge": false,
+      "message": "Switching to Handlebars from Mustache\n\n * Removing Mediawiki support. Because I have not been able to make it work. https://stackoverflow.com/questions/45779754/cannot-authenticate-with-mediawiki-1-28-api\n * Steeping up JGit to latest release. 3.6.2.201501210735-r to 5.10.0.202012080955-r.\n * Refactoring tests to use Approvals."
+    },
+    {
+      "authorEmailAddress": "tomas.bjerre85@gmail.com",
+      "authorName": "Tomas Bjerre",
+      "commitTime": "2020-11-18 17:16:03",
+      "commitTimeLong": 1605719763000,
+      "hash": "73f54645bd6f6fa",
+      "hashFull": "73f54645bd6f6fa17543337ac4b66451f37f03c6",
+      "merge": false,
+      "message": "[Gradle Release Plugin] - new version commit:  \u00271.95-SNAPSHOT\u0027."
+    }
+  ],
+  "tags": [
+    {
+      "authors": [
+        {
+          "commits": [
+            {
+              "authorEmailAddress": "tomas.bjerre85@gmail.com",
+              "authorName": "Tomas Bjerre",
+              "commitTime": "2021-03-29 15:35:07",
+              "commitTimeLong": 1617032107000,
+              "hash": "e78a62ffbb9b57c",
+              "hashFull": "e78a62ffbb9b57cf2b274bab18c7b65eadaf6015",
+              "merge": false,
+              "message": "[Gradle Release Plugin] - new version commit:  \u00271.97-SNAPSHOT\u0027."
+            }
+          ],
+          "authorName": "Tomas Bjerre",
+          "authorEmail": "tomas.bjerre85@gmail.com"
+        }
+      ],
+      "commits": [
+        {
+          "authorEmailAddress": "tomas.bjerre85@gmail.com",
+          "authorName": "Tomas Bjerre",
+          "commitTime": "2021-03-29 15:35:07",
+          "commitTimeLong": 1617032107000,
+          "hash": "e78a62ffbb9b57c",
+          "hashFull": "e78a62ffbb9b57cf2b274bab18c7b65eadaf6015",
+          "merge": false,
+          "message": "[Gradle Release Plugin] - new version commit:  \u00271.97-SNAPSHOT\u0027."
+        }
+      ],
+      "issues": [
+        {
+          "commits": [
+            {
+              "authorEmailAddress": "tomas.bjerre85@gmail.com",
+              "authorName": "Tomas Bjerre",
+              "commitTime": "2021-03-29 15:35:07",
+              "commitTimeLong": 1617032107000,
+              "hash": "e78a62ffbb9b57c",
+              "hashFull": "e78a62ffbb9b57cf2b274bab18c7b65eadaf6015",
+              "merge": false,
+              "message": "[Gradle Release Plugin] - new version commit:  \u00271.97-SNAPSHOT\u0027."
+            }
+          ],
+          "authors": [
+            {
+              "commits": [
+                {
+                  "authorEmailAddress": "tomas.bjerre85@gmail.com",
+                  "authorName": "Tomas Bjerre",
+                  "commitTime": "2021-03-29 15:35:07",
+                  "commitTimeLong": 1617032107000,
+                  "hash": "e78a62ffbb9b57c",
+                  "hashFull": "e78a62ffbb9b57cf2b274bab18c7b65eadaf6015",
+                  "merge": false,
+                  "message": "[Gradle Release Plugin] - new version commit:  \u00271.97-SNAPSHOT\u0027."
+                }
+              ],
+              "authorName": "Tomas Bjerre",
+              "authorEmail": "tomas.bjerre85@gmail.com"
+            }
+          ],
+          "name": "No issue",
+          "title": "",
+          "hasTitle": false,
+          "issue": "",
+          "hasIssue": false,
+          "link": "",
+          "hasLink": false,
+          "type": "",
+          "hasType": false,
+          "hasDescription": false,
+          "description": "",
+          "hasLabels": false,
+          "hasLinkedIssues": false,
+          "issueType": "NOISSUE"
+        }
+      ],
+      "issueTypes": [
+        {
+          "name": "No issue",
+          "issues": [
+            {
+              "commits": [
+                {
+                  "authorEmailAddress": "tomas.bjerre85@gmail.com",
+                  "authorName": "Tomas Bjerre",
+                  "commitTime": "2021-03-29 15:35:07",
+                  "commitTimeLong": 1617032107000,
+                  "hash": "e78a62ffbb9b57c",
+                  "hashFull": "e78a62ffbb9b57cf2b274bab18c7b65eadaf6015",
+                  "merge": false,
+                  "message": "[Gradle Release Plugin] - new version commit:  \u00271.97-SNAPSHOT\u0027."
+                }
+              ],
+              "authors": [
+                {
+                  "commits": [
+                    {
+                      "authorEmailAddress": "tomas.bjerre85@gmail.com",
+                      "authorName": "Tomas Bjerre",
+                      "commitTime": "2021-03-29 15:35:07",
+                      "commitTimeLong": 1617032107000,
+                      "hash": "e78a62ffbb9b57c",
+                      "hashFull": "e78a62ffbb9b57cf2b274bab18c7b65eadaf6015",
+                      "merge": false,
+                      "message": "[Gradle Release Plugin] - new version commit:  \u00271.97-SNAPSHOT\u0027."
+                    }
+                  ],
+                  "authorName": "Tomas Bjerre",
+                  "authorEmail": "tomas.bjerre85@gmail.com"
+                }
+              ],
+              "name": "No issue",
+              "title": "",
+              "hasTitle": false,
+              "issue": "",
+              "hasIssue": false,
+              "link": "",
+              "hasLink": false,
+              "type": "",
+              "hasType": false,
+              "hasDescription": false,
+              "description": "",
+              "hasLabels": false,
+              "hasLinkedIssues": false,
+              "issueType": "NOISSUE"
+            }
+          ],
+          "type": "NOISSUE"
+        }
+      ],
+      "name": "Unreleased",
+      "tagTime": "",
+      "tagTimeLong": -1,
+      "hasTagTime": false
+    },
+    {
+      "annotation": "[Gradle Release Plugin] - creating tag:  \u00271.96\u0027.\n",
+      "authors": [
+        {
+          "commits": [
+            {
+              "authorEmailAddress": "tomas.bjerre85@gmail.com",
+              "authorName": "Tomas Bjerre",
+              "commitTime": "2021-03-29 15:34:15",
+              "commitTimeLong": 1617032055000,
+              "hash": "81936b9d6d9bbb8",
+              "hashFull": "81936b9d6d9bbb84ff860e4e08e132a13909ea16",
+              "merge": false,
+              "message": "[Gradle Release Plugin] - pre tag commit:  \u00271.96\u0027."
+            },
+            {
+              "authorEmailAddress": "tomas.bjerre85@gmail.com",
+              "authorName": "Tomas Bjerre",
+              "commitTime": "2021-03-29 15:33:00",
+              "commitTimeLong": 1617031980000,
+              "hash": "bea18ab90db148c",
+              "hashFull": "bea18ab90db148c3f9a90078424bd6ea36dd5108",
+              "merge": false,
+              "message": "pretty printing output JENKINS-65252"
+            },
+            {
+              "authorEmailAddress": "tomas.bjerre85@gmail.com",
+              "authorName": "Tomas Bjerre",
+              "commitTime": "2021-01-18 16:49:30",
+              "commitTimeLong": 1610988570000,
+              "hash": "8cda1f4c79c8891",
+              "hashFull": "8cda1f4c79c8891510fa81fbb65e6955d4337e33",
+              "merge": false,
+              "message": "[Gradle Release Plugin] - new version commit:  \u00271.96-SNAPSHOT\u0027."
+            }
+          ],
+          "authorName": "Tomas Bjerre",
+          "authorEmail": "tomas.bjerre85@gmail.com"
+        }
+      ],
+      "commits": [
+        {
+          "authorEmailAddress": "tomas.bjerre85@gmail.com",
+          "authorName": "Tomas Bjerre",
+          "commitTime": "2021-03-29 15:34:15",
+          "commitTimeLong": 1617032055000,
+          "hash": "81936b9d6d9bbb8",
+          "hashFull": "81936b9d6d9bbb84ff860e4e08e132a13909ea16",
+          "merge": false,
+          "message": "[Gradle Release Plugin] - pre tag commit:  \u00271.96\u0027."
+        },
+        {
+          "authorEmailAddress": "tomas.bjerre85@gmail.com",
+          "authorName": "Tomas Bjerre",
+          "commitTime": "2021-03-29 15:33:00",
+          "commitTimeLong": 1617031980000,
+          "hash": "bea18ab90db148c",
+          "hashFull": "bea18ab90db148c3f9a90078424bd6ea36dd5108",
+          "merge": false,
+          "message": "pretty printing output JENKINS-65252"
+        },
+        {
+          "authorEmailAddress": "tomas.bjerre85@gmail.com",
+          "authorName": "Tomas Bjerre",
+          "commitTime": "2021-01-18 16:49:30",
+          "commitTimeLong": 1610988570000,
+          "hash": "8cda1f4c79c8891",
+          "hashFull": "8cda1f4c79c8891510fa81fbb65e6955d4337e33",
+          "merge": false,
+          "message": "[Gradle Release Plugin] - new version commit:  \u00271.96-SNAPSHOT\u0027."
+        }
+      ],
+      "issues": [
+        {
+          "commits": [
+            {
+              "authorEmailAddress": "tomas.bjerre85@gmail.com",
+              "authorName": "Tomas Bjerre",
+              "commitTime": "2021-03-29 15:33:00",
+              "commitTimeLong": 1617031980000,
+              "hash": "bea18ab90db148c",
+              "hashFull": "bea18ab90db148c3f9a90078424bd6ea36dd5108",
+              "merge": false,
+              "message": "pretty printing output JENKINS-65252"
+            }
+          ],
+          "authors": [
+            {
+              "commits": [
+                {
+                  "authorEmailAddress": "tomas.bjerre85@gmail.com",
+                  "authorName": "Tomas Bjerre",
+                  "commitTime": "2021-03-29 15:33:00",
+                  "commitTimeLong": 1617031980000,
+                  "hash": "bea18ab90db148c",
+                  "hashFull": "bea18ab90db148c3f9a90078424bd6ea36dd5108",
+                  "merge": false,
+                  "message": "pretty printing output JENKINS-65252"
+                }
+              ],
+              "authorName": "Tomas Bjerre",
+              "authorEmail": "tomas.bjerre85@gmail.com"
+            }
+          ],
+          "name": "Jira",
+          "title": "",
+          "hasTitle": false,
+          "issue": "JENKINS-65252",
+          "hasIssue": true,
+          "link": "",
+          "hasLink": false,
+          "type": "",
+          "hasType": false,
+          "hasDescription": false,
+          "description": "",
+          "hasLabels": false,
+          "hasLinkedIssues": false,
+          "issueType": "JIRA"
+        },
+        {
+          "commits": [
+            {
+              "authorEmailAddress": "tomas.bjerre85@gmail.com",
+              "authorName": "Tomas Bjerre",
+              "commitTime": "2021-03-29 15:34:15",
+              "commitTimeLong": 1617032055000,
+              "hash": "81936b9d6d9bbb8",
+              "hashFull": "81936b9d6d9bbb84ff860e4e08e132a13909ea16",
+              "merge": false,
+              "message": "[Gradle Release Plugin] - pre tag commit:  \u00271.96\u0027."
+            },
+            {
+              "authorEmailAddress": "tomas.bjerre85@gmail.com",
+              "authorName": "Tomas Bjerre",
+              "commitTime": "2021-01-18 16:49:30",
+              "commitTimeLong": 1610988570000,
+              "hash": "8cda1f4c79c8891",
+              "hashFull": "8cda1f4c79c8891510fa81fbb65e6955d4337e33",
+              "merge": false,
+              "message": "[Gradle Release Plugin] - new version commit:  \u00271.96-SNAPSHOT\u0027."
+            }
+          ],
+          "authors": [
+            {
+              "commits": [
+                {
+                  "authorEmailAddress": "tomas.bjerre85@gmail.com",
+                  "authorName": "Tomas Bjerre",
+                  "commitTime": "2021-03-29 15:34:15",
+                  "commitTimeLong": 1617032055000,
+                  "hash": "81936b9d6d9bbb8",
+                  "hashFull": "81936b9d6d9bbb84ff860e4e08e132a13909ea16",
+                  "merge": false,
+                  "message": "[Gradle Release Plugin] - pre tag commit:  \u00271.96\u0027."
+                },
+                {
+                  "authorEmailAddress": "tomas.bjerre85@gmail.com",
+                  "authorName": "Tomas Bjerre",
+                  "commitTime": "2021-01-18 16:49:30",
+                  "commitTimeLong": 1610988570000,
+                  "hash": "8cda1f4c79c8891",
+                  "hashFull": "8cda1f4c79c8891510fa81fbb65e6955d4337e33",
+                  "merge": false,
+                  "message": "[Gradle Release Plugin] - new version commit:  \u00271.96-SNAPSHOT\u0027."
+                }
+              ],
+              "authorName": "Tomas Bjerre",
+              "authorEmail": "tomas.bjerre85@gmail.com"
+            }
+          ],
+          "name": "No issue",
+          "title": "",
+          "hasTitle": false,
+          "issue": "",
+          "hasIssue": false,
+          "link": "",
+          "hasLink": false,
+          "type": "",
+          "hasType": false,
+          "hasDescription": false,
+          "description": "",
+          "hasLabels": false,
+          "hasLinkedIssues": false,
+          "issueType": "NOISSUE"
+        }
+      ],
+      "issueTypes": [
+        {
+          "name": "Jira",
+          "issues": [
+            {
+              "commits": [
+                {
+                  "authorEmailAddress": "tomas.bjerre85@gmail.com",
+                  "authorName": "Tomas Bjerre",
+                  "commitTime": "2021-03-29 15:33:00",
+                  "commitTimeLong": 1617031980000,
+                  "hash": "bea18ab90db148c",
+                  "hashFull": "bea18ab90db148c3f9a90078424bd6ea36dd5108",
+                  "merge": false,
+                  "message": "pretty printing output JENKINS-65252"
+                }
+              ],
+              "authors": [
+                {
+                  "commits": [
+                    {
+                      "authorEmailAddress": "tomas.bjerre85@gmail.com",
+                      "authorName": "Tomas Bjerre",
+                      "commitTime": "2021-03-29 15:33:00",
+                      "commitTimeLong": 1617031980000,
+                      "hash": "bea18ab90db148c",
+                      "hashFull": "bea18ab90db148c3f9a90078424bd6ea36dd5108",
+                      "merge": false,
+                      "message": "pretty printing output JENKINS-65252"
+                    }
+                  ],
+                  "authorName": "Tomas Bjerre",
+                  "authorEmail": "tomas.bjerre85@gmail.com"
+                }
+              ],
+              "name": "Jira",
+              "title": "",
+              "hasTitle": false,
+              "issue": "JENKINS-65252",
+              "hasIssue": true,
+              "link": "",
+              "hasLink": false,
+              "type": "",
+              "hasType": false,
+              "hasDescription": false,
+              "description": "",
+              "hasLabels": false,
+              "hasLinkedIssues": false,
+              "issueType": "JIRA"
+            }
+          ],
+          "type": "JIRA"
+        },
+        {
+          "name": "No issue",
+          "issues": [
+            {
+              "commits": [
+                {
+                  "authorEmailAddress": "tomas.bjerre85@gmail.com",
+                  "authorName": "Tomas Bjerre",
+                  "commitTime": "2021-03-29 15:34:15",
+                  "commitTimeLong": 1617032055000,
+                  "hash": "81936b9d6d9bbb8",
+                  "hashFull": "81936b9d6d9bbb84ff860e4e08e132a13909ea16",
+                  "merge": false,
+                  "message": "[Gradle Release Plugin] - pre tag commit:  \u00271.96\u0027."
+                },
+                {
+                  "authorEmailAddress": "tomas.bjerre85@gmail.com",
+                  "authorName": "Tomas Bjerre",
+                  "commitTime": "2021-01-18 16:49:30",
+                  "commitTimeLong": 1610988570000,
+                  "hash": "8cda1f4c79c8891",
+                  "hashFull": "8cda1f4c79c8891510fa81fbb65e6955d4337e33",
+                  "merge": false,
+                  "message": "[Gradle Release Plugin] - new version commit:  \u00271.96-SNAPSHOT\u0027."
+                }
+              ],
+              "authors": [
+                {
+                  "commits": [
+                    {
+                      "authorEmailAddress": "tomas.bjerre85@gmail.com",
+                      "authorName": "Tomas Bjerre",
+                      "commitTime": "2021-03-29 15:34:15",
+                      "commitTimeLong": 1617032055000,
+                      "hash": "81936b9d6d9bbb8",
+                      "hashFull": "81936b9d6d9bbb84ff860e4e08e132a13909ea16",
+                      "merge": false,
+                      "message": "[Gradle Release Plugin] - pre tag commit:  \u00271.96\u0027."
+                    },
+                    {
+                      "authorEmailAddress": "tomas.bjerre85@gmail.com",
+                      "authorName": "Tomas Bjerre",
+                      "commitTime": "2021-01-18 16:49:30",
+                      "commitTimeLong": 1610988570000,
+                      "hash": "8cda1f4c79c8891",
+                      "hashFull": "8cda1f4c79c8891510fa81fbb65e6955d4337e33",
+                      "merge": false,
+                      "message": "[Gradle Release Plugin] - new version commit:  \u00271.96-SNAPSHOT\u0027."
+                    }
+                  ],
+                  "authorName": "Tomas Bjerre",
+                  "authorEmail": "tomas.bjerre85@gmail.com"
+                }
+              ],
+              "name": "No issue",
+              "title": "",
+              "hasTitle": false,
+              "issue": "",
+              "hasIssue": false,
+              "link": "",
+              "hasLink": false,
+              "type": "",
+              "hasType": false,
+              "hasDescription": false,
+              "description": "",
+              "hasLabels": false,
+              "hasLinkedIssues": false,
+              "issueType": "NOISSUE"
+            }
+          ],
+          "type": "NOISSUE"
+        }
+      ],
+      "name": "1.96",
+      "tagTime": "2021-03-29 15:34:15",
+      "tagTimeLong": 1617032055000,
+      "hasTagTime": true
+    },
+    {
+      "annotation": "[Gradle Release Plugin] - creating tag:  \u00271.95\u0027.\n",
+      "authors": [
+        {
+          "commits": [
+            {
+              "authorEmailAddress": "tomas.bjerre85@gmail.com",
+              "authorName": "Tomas Bjerre",
+              "commitTime": "2021-01-18 16:48:34",
+              "commitTimeLong": 1610988514000,
+              "hash": "da85629f0a0d922",
+              "hashFull": "da85629f0a0d92298c2be0193324a0bc2281f929",
+              "merge": false,
+              "message": "[Gradle Release Plugin] - pre tag commit:  \u00271.95\u0027."
+            },
+            {
+              "authorEmailAddress": "tomas.bjerre85@gmail.com",
+              "authorName": "Tomas Bjerre",
+              "commitTime": "2021-01-18 16:46:13",
+              "commitTimeLong": 1610988373000,
+              "hash": "a57e321f08cea10",
+              "hashFull": "a57e321f08cea10843cc8c7d1c41a1d03318e8d6",
+              "merge": false,
+              "message": "Removing default ignore filter on message\n\nIt was: `^\\[maven-release-plugin\\].*|^\\[Gradle Release Plugin\\].*|^Merge.*\"`\n\nBut users are confused by this and it is probably better to have no filter by default."
+            },
+            {
+              "authorEmailAddress": "tomas.bjerre85@gmail.com",
+              "authorName": "Tomas Bjerre",
+              "commitTime": "2020-12-24 07:11:41",
+              "commitTimeLong": 1608793901000,
+              "hash": "7eba3d038b884b8",
+              "hashFull": "7eba3d038b884b845644c202f6a98632d52fbb9e",
+              "merge": false,
+              "message": "Switching to Handlebars from Mustache\n\n * Removing Mediawiki support. Because I have not been able to make it work. https://stackoverflow.com/questions/45779754/cannot-authenticate-with-mediawiki-1-28-api\n * Steeping up JGit to latest release. 3.6.2.201501210735-r to 5.10.0.202012080955-r.\n * Refactoring tests to use Approvals."
+            },
+            {
+              "authorEmailAddress": "tomas.bjerre85@gmail.com",
+              "authorName": "Tomas Bjerre",
+              "commitTime": "2020-11-18 17:16:03",
+              "commitTimeLong": 1605719763000,
+              "hash": "73f54645bd6f6fa",
+              "hashFull": "73f54645bd6f6fa17543337ac4b66451f37f03c6",
+              "merge": false,
+              "message": "[Gradle Release Plugin] - new version commit:  \u00271.95-SNAPSHOT\u0027."
+            }
+          ],
+          "authorName": "Tomas Bjerre",
+          "authorEmail": "tomas.bjerre85@gmail.com"
+        }
+      ],
+      "commits": [
+        {
+          "authorEmailAddress": "tomas.bjerre85@gmail.com",
+          "authorName": "Tomas Bjerre",
+          "commitTime": "2021-01-18 16:48:34",
+          "commitTimeLong": 1610988514000,
+          "hash": "da85629f0a0d922",
+          "hashFull": "da85629f0a0d92298c2be0193324a0bc2281f929",
+          "merge": false,
+          "message": "[Gradle Release Plugin] - pre tag commit:  \u00271.95\u0027."
+        },
+        {
+          "authorEmailAddress": "tomas.bjerre85@gmail.com",
+          "authorName": "Tomas Bjerre",
+          "commitTime": "2021-01-18 16:46:13",
+          "commitTimeLong": 1610988373000,
+          "hash": "a57e321f08cea10",
+          "hashFull": "a57e321f08cea10843cc8c7d1c41a1d03318e8d6",
+          "merge": false,
+          "message": "Removing default ignore filter on message\n\nIt was: `^\\[maven-release-plugin\\].*|^\\[Gradle Release Plugin\\].*|^Merge.*\"`\n\nBut users are confused by this and it is probably better to have no filter by default."
+        },
+        {
+          "authorEmailAddress": "tomas.bjerre85@gmail.com",
+          "authorName": "Tomas Bjerre",
+          "commitTime": "2020-12-24 07:11:41",
+          "commitTimeLong": 1608793901000,
+          "hash": "7eba3d038b884b8",
+          "hashFull": "7eba3d038b884b845644c202f6a98632d52fbb9e",
+          "merge": false,
+          "message": "Switching to Handlebars from Mustache\n\n * Removing Mediawiki support. Because I have not been able to make it work. https://stackoverflow.com/questions/45779754/cannot-authenticate-with-mediawiki-1-28-api\n * Steeping up JGit to latest release. 3.6.2.201501210735-r to 5.10.0.202012080955-r.\n * Refactoring tests to use Approvals."
+        },
+        {
+          "authorEmailAddress": "tomas.bjerre85@gmail.com",
+          "authorName": "Tomas Bjerre",
+          "commitTime": "2020-11-18 17:16:03",
+          "commitTimeLong": 1605719763000,
+          "hash": "73f54645bd6f6fa",
+          "hashFull": "73f54645bd6f6fa17543337ac4b66451f37f03c6",
+          "merge": false,
+          "message": "[Gradle Release Plugin] - new version commit:  \u00271.95-SNAPSHOT\u0027."
+        }
+      ],
+      "issues": [
+        {
+          "commits": [
+            {
+              "authorEmailAddress": "tomas.bjerre85@gmail.com",
+              "authorName": "Tomas Bjerre",
+              "commitTime": "2020-12-24 07:11:41",
+              "commitTimeLong": 1608793901000,
+              "hash": "7eba3d038b884b8",
+              "hashFull": "7eba3d038b884b845644c202f6a98632d52fbb9e",
+              "merge": false,
+              "message": "Switching to Handlebars from Mustache\n\n * Removing Mediawiki support. Because I have not been able to make it work. https://stackoverflow.com/questions/45779754/cannot-authenticate-with-mediawiki-1-28-api\n * Steeping up JGit to latest release. 3.6.2.201501210735-r to 5.10.0.202012080955-r.\n * Refactoring tests to use Approvals."
+            }
+          ],
+          "authors": [
+            {
+              "commits": [
+                {
+                  "authorEmailAddress": "tomas.bjerre85@gmail.com",
+                  "authorName": "Tomas Bjerre",
+                  "commitTime": "2020-12-24 07:11:41",
+                  "commitTimeLong": 1608793901000,
+                  "hash": "7eba3d038b884b8",
+                  "hashFull": "7eba3d038b884b845644c202f6a98632d52fbb9e",
+                  "merge": false,
+                  "message": "Switching to Handlebars from Mustache\n\n * Removing Mediawiki support. Because I have not been able to make it work. https://stackoverflow.com/questions/45779754/cannot-authenticate-with-mediawiki-1-28-api\n * Steeping up JGit to latest release. 3.6.2.201501210735-r to 5.10.0.202012080955-r.\n * Refactoring tests to use Approvals."
+                }
+              ],
+              "authorName": "Tomas Bjerre",
+              "authorEmail": "tomas.bjerre85@gmail.com"
+            }
+          ],
+          "name": "Jira",
+          "title": "",
+          "hasTitle": false,
+          "issue": "mediawiki-1",
+          "hasIssue": true,
+          "link": "",
+          "hasLink": false,
+          "type": "",
+          "hasType": false,
+          "hasDescription": false,
+          "description": "",
+          "hasLabels": false,
+          "hasLinkedIssues": false,
+          "issueType": "JIRA"
+        },
+        {
+          "commits": [
+            {
+              "authorEmailAddress": "tomas.bjerre85@gmail.com",
+              "authorName": "Tomas Bjerre",
+              "commitTime": "2021-01-18 16:48:34",
+              "commitTimeLong": 1610988514000,
+              "hash": "da85629f0a0d922",
+              "hashFull": "da85629f0a0d92298c2be0193324a0bc2281f929",
+              "merge": false,
+              "message": "[Gradle Release Plugin] - pre tag commit:  \u00271.95\u0027."
+            },
+            {
+              "authorEmailAddress": "tomas.bjerre85@gmail.com",
+              "authorName": "Tomas Bjerre",
+              "commitTime": "2021-01-18 16:46:13",
+              "commitTimeLong": 1610988373000,
+              "hash": "a57e321f08cea10",
+              "hashFull": "a57e321f08cea10843cc8c7d1c41a1d03318e8d6",
+              "merge": false,
+              "message": "Removing default ignore filter on message\n\nIt was: `^\\[maven-release-plugin\\].*|^\\[Gradle Release Plugin\\].*|^Merge.*\"`\n\nBut users are confused by this and it is probably better to have no filter by default."
+            },
+            {
+              "authorEmailAddress": "tomas.bjerre85@gmail.com",
+              "authorName": "Tomas Bjerre",
+              "commitTime": "2020-11-18 17:16:03",
+              "commitTimeLong": 1605719763000,
+              "hash": "73f54645bd6f6fa",
+              "hashFull": "73f54645bd6f6fa17543337ac4b66451f37f03c6",
+              "merge": false,
+              "message": "[Gradle Release Plugin] - new version commit:  \u00271.95-SNAPSHOT\u0027."
+            }
+          ],
+          "authors": [
+            {
+              "commits": [
+                {
+                  "authorEmailAddress": "tomas.bjerre85@gmail.com",
+                  "authorName": "Tomas Bjerre",
+                  "commitTime": "2021-01-18 16:48:34",
+                  "commitTimeLong": 1610988514000,
+                  "hash": "da85629f0a0d922",
+                  "hashFull": "da85629f0a0d92298c2be0193324a0bc2281f929",
+                  "merge": false,
+                  "message": "[Gradle Release Plugin] - pre tag commit:  \u00271.95\u0027."
+                },
+                {
+                  "authorEmailAddress": "tomas.bjerre85@gmail.com",
+                  "authorName": "Tomas Bjerre",
+                  "commitTime": "2021-01-18 16:46:13",
+                  "commitTimeLong": 1610988373000,
+                  "hash": "a57e321f08cea10",
+                  "hashFull": "a57e321f08cea10843cc8c7d1c41a1d03318e8d6",
+                  "merge": false,
+                  "message": "Removing default ignore filter on message\n\nIt was: `^\\[maven-release-plugin\\].*|^\\[Gradle Release Plugin\\].*|^Merge.*\"`\n\nBut users are confused by this and it is probably better to have no filter by default."
+                },
+                {
+                  "authorEmailAddress": "tomas.bjerre85@gmail.com",
+                  "authorName": "Tomas Bjerre",
+                  "commitTime": "2020-11-18 17:16:03",
+                  "commitTimeLong": 1605719763000,
+                  "hash": "73f54645bd6f6fa",
+                  "hashFull": "73f54645bd6f6fa17543337ac4b66451f37f03c6",
+                  "merge": false,
+                  "message": "[Gradle Release Plugin] - new version commit:  \u00271.95-SNAPSHOT\u0027."
+                }
+              ],
+              "authorName": "Tomas Bjerre",
+              "authorEmail": "tomas.bjerre85@gmail.com"
+            }
+          ],
+          "name": "No issue",
+          "title": "",
+          "hasTitle": false,
+          "issue": "",
+          "hasIssue": false,
+          "link": "",
+          "hasLink": false,
+          "type": "",
+          "hasType": false,
+          "hasDescription": false,
+          "description": "",
+          "hasLabels": false,
+          "hasLinkedIssues": false,
+          "issueType": "NOISSUE"
+        }
+      ],
+      "issueTypes": [
+        {
+          "name": "Jira",
+          "issues": [
+            {
+              "commits": [
+                {
+                  "authorEmailAddress": "tomas.bjerre85@gmail.com",
+                  "authorName": "Tomas Bjerre",
+                  "commitTime": "2020-12-24 07:11:41",
+                  "commitTimeLong": 1608793901000,
+                  "hash": "7eba3d038b884b8",
+                  "hashFull": "7eba3d038b884b845644c202f6a98632d52fbb9e",
+                  "merge": false,
+                  "message": "Switching to Handlebars from Mustache\n\n * Removing Mediawiki support. Because I have not been able to make it work. https://stackoverflow.com/questions/45779754/cannot-authenticate-with-mediawiki-1-28-api\n * Steeping up JGit to latest release. 3.6.2.201501210735-r to 5.10.0.202012080955-r.\n * Refactoring tests to use Approvals."
+                }
+              ],
+              "authors": [
+                {
+                  "commits": [
+                    {
+                      "authorEmailAddress": "tomas.bjerre85@gmail.com",
+                      "authorName": "Tomas Bjerre",
+                      "commitTime": "2020-12-24 07:11:41",
+                      "commitTimeLong": 1608793901000,
+                      "hash": "7eba3d038b884b8",
+                      "hashFull": "7eba3d038b884b845644c202f6a98632d52fbb9e",
+                      "merge": false,
+                      "message": "Switching to Handlebars from Mustache\n\n * Removing Mediawiki support. Because I have not been able to make it work. https://stackoverflow.com/questions/45779754/cannot-authenticate-with-mediawiki-1-28-api\n * Steeping up JGit to latest release. 3.6.2.201501210735-r to 5.10.0.202012080955-r.\n * Refactoring tests to use Approvals."
+                    }
+                  ],
+                  "authorName": "Tomas Bjerre",
+                  "authorEmail": "tomas.bjerre85@gmail.com"
+                }
+              ],
+              "name": "Jira",
+              "title": "",
+              "hasTitle": false,
+              "issue": "mediawiki-1",
+              "hasIssue": true,
+              "link": "",
+              "hasLink": false,
+              "type": "",
+              "hasType": false,
+              "hasDescription": false,
+              "description": "",
+              "hasLabels": false,
+              "hasLinkedIssues": false,
+              "issueType": "JIRA"
+            }
+          ],
+          "type": "JIRA"
+        },
+        {
+          "name": "No issue",
+          "issues": [
+            {
+              "commits": [
+                {
+                  "authorEmailAddress": "tomas.bjerre85@gmail.com",
+                  "authorName": "Tomas Bjerre",
+                  "commitTime": "2021-01-18 16:48:34",
+                  "commitTimeLong": 1610988514000,
+                  "hash": "da85629f0a0d922",
+                  "hashFull": "da85629f0a0d92298c2be0193324a0bc2281f929",
+                  "merge": false,
+                  "message": "[Gradle Release Plugin] - pre tag commit:  \u00271.95\u0027."
+                },
+                {
+                  "authorEmailAddress": "tomas.bjerre85@gmail.com",
+                  "authorName": "Tomas Bjerre",
+                  "commitTime": "2021-01-18 16:46:13",
+                  "commitTimeLong": 1610988373000,
+                  "hash": "a57e321f08cea10",
+                  "hashFull": "a57e321f08cea10843cc8c7d1c41a1d03318e8d6",
+                  "merge": false,
+                  "message": "Removing default ignore filter on message\n\nIt was: `^\\[maven-release-plugin\\].*|^\\[Gradle Release Plugin\\].*|^Merge.*\"`\n\nBut users are confused by this and it is probably better to have no filter by default."
+                },
+                {
+                  "authorEmailAddress": "tomas.bjerre85@gmail.com",
+                  "authorName": "Tomas Bjerre",
+                  "commitTime": "2020-11-18 17:16:03",
+                  "commitTimeLong": 1605719763000,
+                  "hash": "73f54645bd6f6fa",
+                  "hashFull": "73f54645bd6f6fa17543337ac4b66451f37f03c6",
+                  "merge": false,
+                  "message": "[Gradle Release Plugin] - new version commit:  \u00271.95-SNAPSHOT\u0027."
+                }
+              ],
+              "authors": [
+                {
+                  "commits": [
+                    {
+                      "authorEmailAddress": "tomas.bjerre85@gmail.com",
+                      "authorName": "Tomas Bjerre",
+                      "commitTime": "2021-01-18 16:48:34",
+                      "commitTimeLong": 1610988514000,
+                      "hash": "da85629f0a0d922",
+                      "hashFull": "da85629f0a0d92298c2be0193324a0bc2281f929",
+                      "merge": false,
+                      "message": "[Gradle Release Plugin] - pre tag commit:  \u00271.95\u0027."
+                    },
+                    {
+                      "authorEmailAddress": "tomas.bjerre85@gmail.com",
+                      "authorName": "Tomas Bjerre",
+                      "commitTime": "2021-01-18 16:46:13",
+                      "commitTimeLong": 1610988373000,
+                      "hash": "a57e321f08cea10",
+                      "hashFull": "a57e321f08cea10843cc8c7d1c41a1d03318e8d6",
+                      "merge": false,
+                      "message": "Removing default ignore filter on message\n\nIt was: `^\\[maven-release-plugin\\].*|^\\[Gradle Release Plugin\\].*|^Merge.*\"`\n\nBut users are confused by this and it is probably better to have no filter by default."
+                    },
+                    {
+                      "authorEmailAddress": "tomas.bjerre85@gmail.com",
+                      "authorName": "Tomas Bjerre",
+                      "commitTime": "2020-11-18 17:16:03",
+                      "commitTimeLong": 1605719763000,
+                      "hash": "73f54645bd6f6fa",
+                      "hashFull": "73f54645bd6f6fa17543337ac4b66451f37f03c6",
+                      "merge": false,
+                      "message": "[Gradle Release Plugin] - new version commit:  \u00271.95-SNAPSHOT\u0027."
+                    }
+                  ],
+                  "authorName": "Tomas Bjerre",
+                  "authorEmail": "tomas.bjerre85@gmail.com"
+                }
+              ],
+              "name": "No issue",
+              "title": "",
+              "hasTitle": false,
+              "issue": "",
+              "hasIssue": false,
+              "link": "",
+              "hasLink": false,
+              "type": "",
+              "hasType": false,
+              "hasDescription": false,
+              "description": "",
+              "hasLabels": false,
+              "hasLinkedIssues": false,
+              "issueType": "NOISSUE"
+            }
+          ],
+          "type": "NOISSUE"
+        }
+      ],
+      "name": "1.95",
+      "tagTime": "2021-01-18 16:48:34",
+      "tagTimeLong": 1610988514000,
+      "hasTagTime": true
+    }
+  ],
+  "authors": [
+    {
+      "commits": [
+        {
+          "authorEmailAddress": "tomas.bjerre85@gmail.com",
+          "authorName": "Tomas Bjerre",
+          "commitTime": "2021-03-29 15:35:07",
+          "commitTimeLong": 1617032107000,
+          "hash": "e78a62ffbb9b57c",
+          "hashFull": "e78a62ffbb9b57cf2b274bab18c7b65eadaf6015",
+          "merge": false,
+          "message": "[Gradle Release Plugin] - new version commit:  \u00271.97-SNAPSHOT\u0027."
+        },
+        {
+          "authorEmailAddress": "tomas.bjerre85@gmail.com",
+          "authorName": "Tomas Bjerre",
+          "commitTime": "2021-03-29 15:34:15",
+          "commitTimeLong": 1617032055000,
+          "hash": "81936b9d6d9bbb8",
+          "hashFull": "81936b9d6d9bbb84ff860e4e08e132a13909ea16",
+          "merge": false,
+          "message": "[Gradle Release Plugin] - pre tag commit:  \u00271.96\u0027."
+        },
+        {
+          "authorEmailAddress": "tomas.bjerre85@gmail.com",
+          "authorName": "Tomas Bjerre",
+          "commitTime": "2021-03-29 15:33:00",
+          "commitTimeLong": 1617031980000,
+          "hash": "bea18ab90db148c",
+          "hashFull": "bea18ab90db148c3f9a90078424bd6ea36dd5108",
+          "merge": false,
+          "message": "pretty printing output JENKINS-65252"
+        },
+        {
+          "authorEmailAddress": "tomas.bjerre85@gmail.com",
+          "authorName": "Tomas Bjerre",
+          "commitTime": "2021-01-18 16:49:30",
+          "commitTimeLong": 1610988570000,
+          "hash": "8cda1f4c79c8891",
+          "hashFull": "8cda1f4c79c8891510fa81fbb65e6955d4337e33",
+          "merge": false,
+          "message": "[Gradle Release Plugin] - new version commit:  \u00271.96-SNAPSHOT\u0027."
+        },
+        {
+          "authorEmailAddress": "tomas.bjerre85@gmail.com",
+          "authorName": "Tomas Bjerre",
+          "commitTime": "2021-01-18 16:48:34",
+          "commitTimeLong": 1610988514000,
+          "hash": "da85629f0a0d922",
+          "hashFull": "da85629f0a0d92298c2be0193324a0bc2281f929",
+          "merge": false,
+          "message": "[Gradle Release Plugin] - pre tag commit:  \u00271.95\u0027."
+        },
+        {
+          "authorEmailAddress": "tomas.bjerre85@gmail.com",
+          "authorName": "Tomas Bjerre",
+          "commitTime": "2021-01-18 16:46:13",
+          "commitTimeLong": 1610988373000,
+          "hash": "a57e321f08cea10",
+          "hashFull": "a57e321f08cea10843cc8c7d1c41a1d03318e8d6",
+          "merge": false,
+          "message": "Removing default ignore filter on message\n\nIt was: `^\\[maven-release-plugin\\].*|^\\[Gradle Release Plugin\\].*|^Merge.*\"`\n\nBut users are confused by this and it is probably better to have no filter by default."
+        },
+        {
+          "authorEmailAddress": "tomas.bjerre85@gmail.com",
+          "authorName": "Tomas Bjerre",
+          "commitTime": "2020-12-24 07:11:41",
+          "commitTimeLong": 1608793901000,
+          "hash": "7eba3d038b884b8",
+          "hashFull": "7eba3d038b884b845644c202f6a98632d52fbb9e",
+          "merge": false,
+          "message": "Switching to Handlebars from Mustache\n\n * Removing Mediawiki support. Because I have not been able to make it work. https://stackoverflow.com/questions/45779754/cannot-authenticate-with-mediawiki-1-28-api\n * Steeping up JGit to latest release. 3.6.2.201501210735-r to 5.10.0.202012080955-r.\n * Refactoring tests to use Approvals."
+        },
+        {
+          "authorEmailAddress": "tomas.bjerre85@gmail.com",
+          "authorName": "Tomas Bjerre",
+          "commitTime": "2020-11-18 17:16:03",
+          "commitTimeLong": 1605719763000,
+          "hash": "73f54645bd6f6fa",
+          "hashFull": "73f54645bd6f6fa17543337ac4b66451f37f03c6",
+          "merge": false,
+          "message": "[Gradle Release Plugin] - new version commit:  \u00271.95-SNAPSHOT\u0027."
+        }
+      ],
+      "authorName": "Tomas Bjerre",
+      "authorEmail": "tomas.bjerre85@gmail.com"
+    }
+  ],
+  "issues": [
+    {
+      "commits": [
+        {
+          "authorEmailAddress": "tomas.bjerre85@gmail.com",
+          "authorName": "Tomas Bjerre",
+          "commitTime": "2021-03-29 15:33:00",
+          "commitTimeLong": 1617031980000,
+          "hash": "bea18ab90db148c",
+          "hashFull": "bea18ab90db148c3f9a90078424bd6ea36dd5108",
+          "merge": false,
+          "message": "pretty printing output JENKINS-65252"
+        }
+      ],
+      "authors": [
+        {
+          "commits": [
+            {
+              "authorEmailAddress": "tomas.bjerre85@gmail.com",
+              "authorName": "Tomas Bjerre",
+              "commitTime": "2021-03-29 15:33:00",
+              "commitTimeLong": 1617031980000,
+              "hash": "bea18ab90db148c",
+              "hashFull": "bea18ab90db148c3f9a90078424bd6ea36dd5108",
+              "merge": false,
+              "message": "pretty printing output JENKINS-65252"
+            }
+          ],
+          "authorName": "Tomas Bjerre",
+          "authorEmail": "tomas.bjerre85@gmail.com"
+        }
+      ],
+      "name": "Jira",
+      "title": "",
+      "hasTitle": false,
+      "issue": "JENKINS-65252",
+      "hasIssue": true,
+      "link": "",
+      "hasLink": false,
+      "type": "",
+      "hasType": false,
+      "hasDescription": false,
+      "description": "",
+      "hasLabels": false,
+      "hasLinkedIssues": false,
+      "issueType": "JIRA"
+    },
+    {
+      "commits": [
+        {
+          "authorEmailAddress": "tomas.bjerre85@gmail.com",
+          "authorName": "Tomas Bjerre",
+          "commitTime": "2020-12-24 07:11:41",
+          "commitTimeLong": 1608793901000,
+          "hash": "7eba3d038b884b8",
+          "hashFull": "7eba3d038b884b845644c202f6a98632d52fbb9e",
+          "merge": false,
+          "message": "Switching to Handlebars from Mustache\n\n * Removing Mediawiki support. Because I have not been able to make it work. https://stackoverflow.com/questions/45779754/cannot-authenticate-with-mediawiki-1-28-api\n * Steeping up JGit to latest release. 3.6.2.201501210735-r to 5.10.0.202012080955-r.\n * Refactoring tests to use Approvals."
+        }
+      ],
+      "authors": [
+        {
+          "commits": [
+            {
+              "authorEmailAddress": "tomas.bjerre85@gmail.com",
+              "authorName": "Tomas Bjerre",
+              "commitTime": "2020-12-24 07:11:41",
+              "commitTimeLong": 1608793901000,
+              "hash": "7eba3d038b884b8",
+              "hashFull": "7eba3d038b884b845644c202f6a98632d52fbb9e",
+              "merge": false,
+              "message": "Switching to Handlebars from Mustache\n\n * Removing Mediawiki support. Because I have not been able to make it work. https://stackoverflow.com/questions/45779754/cannot-authenticate-with-mediawiki-1-28-api\n * Steeping up JGit to latest release. 3.6.2.201501210735-r to 5.10.0.202012080955-r.\n * Refactoring tests to use Approvals."
+            }
+          ],
+          "authorName": "Tomas Bjerre",
+          "authorEmail": "tomas.bjerre85@gmail.com"
+        }
+      ],
+      "name": "Jira",
+      "title": "",
+      "hasTitle": false,
+      "issue": "mediawiki-1",
+      "hasIssue": true,
+      "link": "",
+      "hasLink": false,
+      "type": "",
+      "hasType": false,
+      "hasDescription": false,
+      "description": "",
+      "hasLabels": false,
+      "hasLinkedIssues": false,
+      "issueType": "JIRA"
+    },
+    {
+      "commits": [
+        {
+          "authorEmailAddress": "tomas.bjerre85@gmail.com",
+          "authorName": "Tomas Bjerre",
+          "commitTime": "2021-03-29 15:35:07",
+          "commitTimeLong": 1617032107000,
+          "hash": "e78a62ffbb9b57c",
+          "hashFull": "e78a62ffbb9b57cf2b274bab18c7b65eadaf6015",
+          "merge": false,
+          "message": "[Gradle Release Plugin] - new version commit:  \u00271.97-SNAPSHOT\u0027."
+        },
+        {
+          "authorEmailAddress": "tomas.bjerre85@gmail.com",
+          "authorName": "Tomas Bjerre",
+          "commitTime": "2021-03-29 15:34:15",
+          "commitTimeLong": 1617032055000,
+          "hash": "81936b9d6d9bbb8",
+          "hashFull": "81936b9d6d9bbb84ff860e4e08e132a13909ea16",
+          "merge": false,
+          "message": "[Gradle Release Plugin] - pre tag commit:  \u00271.96\u0027."
+        },
+        {
+          "authorEmailAddress": "tomas.bjerre85@gmail.com",
+          "authorName": "Tomas Bjerre",
+          "commitTime": "2021-01-18 16:49:30",
+          "commitTimeLong": 1610988570000,
+          "hash": "8cda1f4c79c8891",
+          "hashFull": "8cda1f4c79c8891510fa81fbb65e6955d4337e33",
+          "merge": false,
+          "message": "[Gradle Release Plugin] - new version commit:  \u00271.96-SNAPSHOT\u0027."
+        },
+        {
+          "authorEmailAddress": "tomas.bjerre85@gmail.com",
+          "authorName": "Tomas Bjerre",
+          "commitTime": "2021-01-18 16:48:34",
+          "commitTimeLong": 1610988514000,
+          "hash": "da85629f0a0d922",
+          "hashFull": "da85629f0a0d92298c2be0193324a0bc2281f929",
+          "merge": false,
+          "message": "[Gradle Release Plugin] - pre tag commit:  \u00271.95\u0027."
+        },
+        {
+          "authorEmailAddress": "tomas.bjerre85@gmail.com",
+          "authorName": "Tomas Bjerre",
+          "commitTime": "2021-01-18 16:46:13",
+          "commitTimeLong": 1610988373000,
+          "hash": "a57e321f08cea10",
+          "hashFull": "a57e321f08cea10843cc8c7d1c41a1d03318e8d6",
+          "merge": false,
+          "message": "Removing default ignore filter on message\n\nIt was: `^\\[maven-release-plugin\\].*|^\\[Gradle Release Plugin\\].*|^Merge.*\"`\n\nBut users are confused by this and it is probably better to have no filter by default."
+        },
+        {
+          "authorEmailAddress": "tomas.bjerre85@gmail.com",
+          "authorName": "Tomas Bjerre",
+          "commitTime": "2020-11-18 17:16:03",
+          "commitTimeLong": 1605719763000,
+          "hash": "73f54645bd6f6fa",
+          "hashFull": "73f54645bd6f6fa17543337ac4b66451f37f03c6",
+          "merge": false,
+          "message": "[Gradle Release Plugin] - new version commit:  \u00271.95-SNAPSHOT\u0027."
+        }
+      ],
+      "authors": [
+        {
+          "commits": [
+            {
+              "authorEmailAddress": "tomas.bjerre85@gmail.com",
+              "authorName": "Tomas Bjerre",
+              "commitTime": "2021-03-29 15:35:07",
+              "commitTimeLong": 1617032107000,
+              "hash": "e78a62ffbb9b57c",
+              "hashFull": "e78a62ffbb9b57cf2b274bab18c7b65eadaf6015",
+              "merge": false,
+              "message": "[Gradle Release Plugin] - new version commit:  \u00271.97-SNAPSHOT\u0027."
+            },
+            {
+              "authorEmailAddress": "tomas.bjerre85@gmail.com",
+              "authorName": "Tomas Bjerre",
+              "commitTime": "2021-03-29 15:34:15",
+              "commitTimeLong": 1617032055000,
+              "hash": "81936b9d6d9bbb8",
+              "hashFull": "81936b9d6d9bbb84ff860e4e08e132a13909ea16",
+              "merge": false,
+              "message": "[Gradle Release Plugin] - pre tag commit:  \u00271.96\u0027."
+            },
+            {
+              "authorEmailAddress": "tomas.bjerre85@gmail.com",
+              "authorName": "Tomas Bjerre",
+              "commitTime": "2021-01-18 16:49:30",
+              "commitTimeLong": 1610988570000,
+              "hash": "8cda1f4c79c8891",
+              "hashFull": "8cda1f4c79c8891510fa81fbb65e6955d4337e33",
+              "merge": false,
+              "message": "[Gradle Release Plugin] - new version commit:  \u00271.96-SNAPSHOT\u0027."
+            },
+            {
+              "authorEmailAddress": "tomas.bjerre85@gmail.com",
+              "authorName": "Tomas Bjerre",
+              "commitTime": "2021-01-18 16:48:34",
+              "commitTimeLong": 1610988514000,
+              "hash": "da85629f0a0d922",
+              "hashFull": "da85629f0a0d92298c2be0193324a0bc2281f929",
+              "merge": false,
+              "message": "[Gradle Release Plugin] - pre tag commit:  \u00271.95\u0027."
+            },
+            {
+              "authorEmailAddress": "tomas.bjerre85@gmail.com",
+              "authorName": "Tomas Bjerre",
+              "commitTime": "2021-01-18 16:46:13",
+              "commitTimeLong": 1610988373000,
+              "hash": "a57e321f08cea10",
+              "hashFull": "a57e321f08cea10843cc8c7d1c41a1d03318e8d6",
+              "merge": false,
+              "message": "Removing default ignore filter on message\n\nIt was: `^\\[maven-release-plugin\\].*|^\\[Gradle Release Plugin\\].*|^Merge.*\"`\n\nBut users are confused by this and it is probably better to have no filter by default."
+            },
+            {
+              "authorEmailAddress": "tomas.bjerre85@gmail.com",
+              "authorName": "Tomas Bjerre",
+              "commitTime": "2020-11-18 17:16:03",
+              "commitTimeLong": 1605719763000,
+              "hash": "73f54645bd6f6fa",
+              "hashFull": "73f54645bd6f6fa17543337ac4b66451f37f03c6",
+              "merge": false,
+              "message": "[Gradle Release Plugin] - new version commit:  \u00271.95-SNAPSHOT\u0027."
+            }
+          ],
+          "authorName": "Tomas Bjerre",
+          "authorEmail": "tomas.bjerre85@gmail.com"
+        }
+      ],
+      "name": "No issue",
+      "title": "",
+      "hasTitle": false,
+      "issue": "",
+      "hasIssue": false,
+      "link": "",
+      "hasLink": false,
+      "type": "",
+      "hasType": false,
+      "hasDescription": false,
+      "description": "",
+      "hasLabels": false,
+      "hasLinkedIssues": false,
+      "issueType": "NOISSUE"
+    }
+  ],
+  "issueTypes": [
+    {
+      "name": "Jira",
+      "issues": [
+        {
+          "commits": [
+            {
+              "authorEmailAddress": "tomas.bjerre85@gmail.com",
+              "authorName": "Tomas Bjerre",
+              "commitTime": "2021-03-29 15:33:00",
+              "commitTimeLong": 1617031980000,
+              "hash": "bea18ab90db148c",
+              "hashFull": "bea18ab90db148c3f9a90078424bd6ea36dd5108",
+              "merge": false,
+              "message": "pretty printing output JENKINS-65252"
+            }
+          ],
+          "authors": [
+            {
+              "commits": [
+                {
+                  "authorEmailAddress": "tomas.bjerre85@gmail.com",
+                  "authorName": "Tomas Bjerre",
+                  "commitTime": "2021-03-29 15:33:00",
+                  "commitTimeLong": 1617031980000,
+                  "hash": "bea18ab90db148c",
+                  "hashFull": "bea18ab90db148c3f9a90078424bd6ea36dd5108",
+                  "merge": false,
+                  "message": "pretty printing output JENKINS-65252"
+                }
+              ],
+              "authorName": "Tomas Bjerre",
+              "authorEmail": "tomas.bjerre85@gmail.com"
+            }
+          ],
+          "name": "Jira",
+          "title": "",
+          "hasTitle": false,
+          "issue": "JENKINS-65252",
+          "hasIssue": true,
+          "link": "",
+          "hasLink": false,
+          "type": "",
+          "hasType": false,
+          "hasDescription": false,
+          "description": "",
+          "hasLabels": false,
+          "hasLinkedIssues": false,
+          "issueType": "JIRA"
+        },
+        {
+          "commits": [
+            {
+              "authorEmailAddress": "tomas.bjerre85@gmail.com",
+              "authorName": "Tomas Bjerre",
+              "commitTime": "2020-12-24 07:11:41",
+              "commitTimeLong": 1608793901000,
+              "hash": "7eba3d038b884b8",
+              "hashFull": "7eba3d038b884b845644c202f6a98632d52fbb9e",
+              "merge": false,
+              "message": "Switching to Handlebars from Mustache\n\n * Removing Mediawiki support. Because I have not been able to make it work. https://stackoverflow.com/questions/45779754/cannot-authenticate-with-mediawiki-1-28-api\n * Steeping up JGit to latest release. 3.6.2.201501210735-r to 5.10.0.202012080955-r.\n * Refactoring tests to use Approvals."
+            }
+          ],
+          "authors": [
+            {
+              "commits": [
+                {
+                  "authorEmailAddress": "tomas.bjerre85@gmail.com",
+                  "authorName": "Tomas Bjerre",
+                  "commitTime": "2020-12-24 07:11:41",
+                  "commitTimeLong": 1608793901000,
+                  "hash": "7eba3d038b884b8",
+                  "hashFull": "7eba3d038b884b845644c202f6a98632d52fbb9e",
+                  "merge": false,
+                  "message": "Switching to Handlebars from Mustache\n\n * Removing Mediawiki support. Because I have not been able to make it work. https://stackoverflow.com/questions/45779754/cannot-authenticate-with-mediawiki-1-28-api\n * Steeping up JGit to latest release. 3.6.2.201501210735-r to 5.10.0.202012080955-r.\n * Refactoring tests to use Approvals."
+                }
+              ],
+              "authorName": "Tomas Bjerre",
+              "authorEmail": "tomas.bjerre85@gmail.com"
+            }
+          ],
+          "name": "Jira",
+          "title": "",
+          "hasTitle": false,
+          "issue": "mediawiki-1",
+          "hasIssue": true,
+          "link": "",
+          "hasLink": false,
+          "type": "",
+          "hasType": false,
+          "hasDescription": false,
+          "description": "",
+          "hasLabels": false,
+          "hasLinkedIssues": false,
+          "issueType": "JIRA"
+        }
+      ],
+      "type": "JIRA"
+    },
+    {
+      "name": "No issue",
+      "issues": [
+        {
+          "commits": [
+            {
+              "authorEmailAddress": "tomas.bjerre85@gmail.com",
+              "authorName": "Tomas Bjerre",
+              "commitTime": "2021-03-29 15:35:07",
+              "commitTimeLong": 1617032107000,
+              "hash": "e78a62ffbb9b57c",
+              "hashFull": "e78a62ffbb9b57cf2b274bab18c7b65eadaf6015",
+              "merge": false,
+              "message": "[Gradle Release Plugin] - new version commit:  \u00271.97-SNAPSHOT\u0027."
+            },
+            {
+              "authorEmailAddress": "tomas.bjerre85@gmail.com",
+              "authorName": "Tomas Bjerre",
+              "commitTime": "2021-03-29 15:34:15",
+              "commitTimeLong": 1617032055000,
+              "hash": "81936b9d6d9bbb8",
+              "hashFull": "81936b9d6d9bbb84ff860e4e08e132a13909ea16",
+              "merge": false,
+              "message": "[Gradle Release Plugin] - pre tag commit:  \u00271.96\u0027."
+            },
+            {
+              "authorEmailAddress": "tomas.bjerre85@gmail.com",
+              "authorName": "Tomas Bjerre",
+              "commitTime": "2021-01-18 16:49:30",
+              "commitTimeLong": 1610988570000,
+              "hash": "8cda1f4c79c8891",
+              "hashFull": "8cda1f4c79c8891510fa81fbb65e6955d4337e33",
+              "merge": false,
+              "message": "[Gradle Release Plugin] - new version commit:  \u00271.96-SNAPSHOT\u0027."
+            },
+            {
+              "authorEmailAddress": "tomas.bjerre85@gmail.com",
+              "authorName": "Tomas Bjerre",
+              "commitTime": "2021-01-18 16:48:34",
+              "commitTimeLong": 1610988514000,
+              "hash": "da85629f0a0d922",
+              "hashFull": "da85629f0a0d92298c2be0193324a0bc2281f929",
+              "merge": false,
+              "message": "[Gradle Release Plugin] - pre tag commit:  \u00271.95\u0027."
+            },
+            {
+              "authorEmailAddress": "tomas.bjerre85@gmail.com",
+              "authorName": "Tomas Bjerre",
+              "commitTime": "2021-01-18 16:46:13",
+              "commitTimeLong": 1610988373000,
+              "hash": "a57e321f08cea10",
+              "hashFull": "a57e321f08cea10843cc8c7d1c41a1d03318e8d6",
+              "merge": false,
+              "message": "Removing default ignore filter on message\n\nIt was: `^\\[maven-release-plugin\\].*|^\\[Gradle Release Plugin\\].*|^Merge.*\"`\n\nBut users are confused by this and it is probably better to have no filter by default."
+            },
+            {
+              "authorEmailAddress": "tomas.bjerre85@gmail.com",
+              "authorName": "Tomas Bjerre",
+              "commitTime": "2020-11-18 17:16:03",
+              "commitTimeLong": 1605719763000,
+              "hash": "73f54645bd6f6fa",
+              "hashFull": "73f54645bd6f6fa17543337ac4b66451f37f03c6",
+              "merge": false,
+              "message": "[Gradle Release Plugin] - new version commit:  \u00271.95-SNAPSHOT\u0027."
+            }
+          ],
+          "authors": [
+            {
+              "commits": [
+                {
+                  "authorEmailAddress": "tomas.bjerre85@gmail.com",
+                  "authorName": "Tomas Bjerre",
+                  "commitTime": "2021-03-29 15:35:07",
+                  "commitTimeLong": 1617032107000,
+                  "hash": "e78a62ffbb9b57c",
+                  "hashFull": "e78a62ffbb9b57cf2b274bab18c7b65eadaf6015",
+                  "merge": false,
+                  "message": "[Gradle Release Plugin] - new version commit:  \u00271.97-SNAPSHOT\u0027."
+                },
+                {
+                  "authorEmailAddress": "tomas.bjerre85@gmail.com",
+                  "authorName": "Tomas Bjerre",
+                  "commitTime": "2021-03-29 15:34:15",
+                  "commitTimeLong": 1617032055000,
+                  "hash": "81936b9d6d9bbb8",
+                  "hashFull": "81936b9d6d9bbb84ff860e4e08e132a13909ea16",
+                  "merge": false,
+                  "message": "[Gradle Release Plugin] - pre tag commit:  \u00271.96\u0027."
+                },
+                {
+                  "authorEmailAddress": "tomas.bjerre85@gmail.com",
+                  "authorName": "Tomas Bjerre",
+                  "commitTime": "2021-01-18 16:49:30",
+                  "commitTimeLong": 1610988570000,
+                  "hash": "8cda1f4c79c8891",
+                  "hashFull": "8cda1f4c79c8891510fa81fbb65e6955d4337e33",
+                  "merge": false,
+                  "message": "[Gradle Release Plugin] - new version commit:  \u00271.96-SNAPSHOT\u0027."
+                },
+                {
+                  "authorEmailAddress": "tomas.bjerre85@gmail.com",
+                  "authorName": "Tomas Bjerre",
+                  "commitTime": "2021-01-18 16:48:34",
+                  "commitTimeLong": 1610988514000,
+                  "hash": "da85629f0a0d922",
+                  "hashFull": "da85629f0a0d92298c2be0193324a0bc2281f929",
+                  "merge": false,
+                  "message": "[Gradle Release Plugin] - pre tag commit:  \u00271.95\u0027."
+                },
+                {
+                  "authorEmailAddress": "tomas.bjerre85@gmail.com",
+                  "authorName": "Tomas Bjerre",
+                  "commitTime": "2021-01-18 16:46:13",
+                  "commitTimeLong": 1610988373000,
+                  "hash": "a57e321f08cea10",
+                  "hashFull": "a57e321f08cea10843cc8c7d1c41a1d03318e8d6",
+                  "merge": false,
+                  "message": "Removing default ignore filter on message\n\nIt was: `^\\[maven-release-plugin\\].*|^\\[Gradle Release Plugin\\].*|^Merge.*\"`\n\nBut users are confused by this and it is probably better to have no filter by default."
+                },
+                {
+                  "authorEmailAddress": "tomas.bjerre85@gmail.com",
+                  "authorName": "Tomas Bjerre",
+                  "commitTime": "2020-11-18 17:16:03",
+                  "commitTimeLong": 1605719763000,
+                  "hash": "73f54645bd6f6fa",
+                  "hashFull": "73f54645bd6f6fa17543337ac4b66451f37f03c6",
+                  "merge": false,
+                  "message": "[Gradle Release Plugin] - new version commit:  \u00271.95-SNAPSHOT\u0027."
+                }
+              ],
+              "authorName": "Tomas Bjerre",
+              "authorEmail": "tomas.bjerre85@gmail.com"
+            }
+          ],
+          "name": "No issue",
+          "title": "",
+          "hasTitle": false,
+          "issue": "",
+          "hasIssue": false,
+          "link": "",
+          "hasLink": false,
+          "type": "",
+          "hasType": false,
+          "hasDescription": false,
+          "description": "",
+          "hasLabels": false,
+          "hasLinkedIssues": false,
+          "issueType": "NOISSUE"
+        }
+      ],
+      "type": "NOISSUE"
+    }
+  ],
+  "ownerName": "tomasbjerre",
+  "repoName": "git-changelog-lib"
+}

--- a/src/test/resources/templatetest/helpers/helper.js
+++ b/src/test/resources/templatetest/helpers/helper.js
@@ -1,0 +1,3 @@
+Handlebars.registerHelper("firstWord", function(options) {
+  return options.fn(this).split(" ")[0];
+});


### PR DESCRIPTION
It would be nice to be able to define the Javascript Handlebars helpers in a separate file.
For the maven plugin, this will have the benefit of not having to put Javascript code into the pom.xml.