### PR TITLE
feat: Add helpers "ifContainsTypeOtherThan" and "ifCommitTypeOtherThan"

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,16 @@ Conditional, renders a block if given `List<Commits>` contains given `type`.
 {{/ifContainsType}}
 ```
 
+### `ifContainsTypeOtherThan <List<Commit>>`
+
+Conditional, renders a block if given `List<Commits>` contains commits that don't match the given `type`.
+
+```hbs
+{{#ifContainsTypeOtherThan commits type="fix"}}
+  commits contains other types than fix
+{{/ifContainsTypeOtherThan}}
+```
+
 ### `ifContainsBreaking <List<Commit>>`
 
 Conditional, renders a block if given `List<Commits>` contains `breaking` changes.
@@ -233,6 +243,16 @@ Conditional, renders a block if given `Commit` is of `type`.
 ```hbs
 {{#commits}}
  {{#ifCommitType . type="fix"}} is type fix {{/ifCommitType}}
+{{/commits}}
+```
+
+### `ifCommitType <Commit> type="<type>"`
+
+Conditional, renders a block if given `Commit` is of `type`.
+
+```hbs
+{{#commits}}
+ {{#ifCommitTypeOtherThan . type="fix"}} is not type fix {{/ifCommitTypeOtherThan}}
 {{/commits}}
 ```
 

--- a/src/main/java/se/bjurr/gitchangelog/api/helpers/Helpers.java
+++ b/src/main/java/se/bjurr/gitchangelog/api/helpers/Helpers.java
@@ -9,6 +9,7 @@ import static se.bjurr.gitchangelog.internal.semantic.ConventionalCommitParser.c
 import static se.bjurr.gitchangelog.internal.semantic.ConventionalCommitParser.commitType;
 import static se.bjurr.gitchangelog.internal.semantic.ConventionalCommitParser.containsBreaking;
 import static se.bjurr.gitchangelog.internal.semantic.ConventionalCommitParser.containsType;
+import static se.bjurr.gitchangelog.internal.semantic.ConventionalCommitParser.containsTypeOtherThan;
 import static se.bjurr.gitchangelog.internal.semantic.ConventionalCommitParser.getDate;
 import static se.bjurr.gitchangelog.internal.semantic.ConventionalCommitParser.getMessageParts;
 import static se.bjurr.gitchangelog.internal.semantic.ConventionalCommitParser.isReleaseTag;
@@ -81,6 +82,11 @@ public class Helpers {
           return conditional(options, containsType(commits, options));
         });
     ALL.put(
+        "ifContainsTypeOtherThan",
+        (final List<Commit> commits, final Options options) -> {
+          return conditional(options, containsTypeOtherThan(commits, options));
+        });
+    ALL.put(
         "ifContainsBreaking",
         (final List<Commit> commits, final Options options) -> {
           return conditional(options, containsBreaking(commits, options));
@@ -90,6 +96,11 @@ public class Helpers {
         "ifCommitType",
         (final Commit commit, final Options options) -> {
           return conditional(options, commitType(commit.getMessage(), options));
+        });
+    ALL.put(
+        "ifCommitTypeOtherThan",
+        (final Commit commit, final Options options) -> {
+          return conditional(options, !commitType(commit.getMessage(), options));
         });
 
     ALL.put(

--- a/src/main/java/se/bjurr/gitchangelog/internal/semantic/ConventionalCommitParser.java
+++ b/src/main/java/se/bjurr/gitchangelog/internal/semantic/ConventionalCommitParser.java
@@ -129,6 +129,15 @@ public class ConventionalCommitParser {
     return false;
   }
 
+  public static boolean containsTypeOtherThan(final List<Commit> commits, final Options options) {
+    for (final Commit commit : commits) {
+      if (!commitType(commit.getMessage(), options)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
   public static boolean commitType(final String commitMessage, final Options options) {
     final String type = options.hash("type").toString();
     return getType(commitMessage).matches(type);

--- a/src/test/java/se/bjurr/gitchangelog/api/helpers/HandlebarsHelperTest.testThatBuiltInHelperMethodsCanBeUsed.approved.txt
+++ b/src/test/java/se/bjurr/gitchangelog/api/helpers/HandlebarsHelperTest.testThatBuiltInHelperMethodsCanBeUsed.approved.txt
@@ -89,6 +89,10 @@ Has paragraphs: {{hash}}
   commits contains fix
  {{/ifContainsType}}
 
+ {{#ifContainsTypeOtherThan commits type="fix"}}
+  commits contains other types than fix
+ {{/ifContainsTypeOtherThan}}
+
  date: {{tagDate .}} 
  
 {{/tags}}
@@ -102,6 +106,7 @@ Has paragraphs: {{hash}}
  {{#ifCommitType . type="fix"}} is type fix {{/ifCommitType}}
  {{#ifCommitType . type=""}} commit has no type {{/ifCommitType}}
  {{#ifCommitType . type="fix|revert"}} commit has type fix or revert {{/ifCommitType}}
+ {{#ifCommitTypeOtherThan . type="fix|revert"}} commit has not type fix or revert {{/ifCommitTypeOtherThan}}
 
  {{#ifCommitScope . scope="utils"}} is scope utils {{/ifCommitScope}}
 
@@ -342,6 +347,8 @@ This reverts commit 1edc0d71eccce51abfb5f62fdddfbe73913785f5.
  
   commits contains fix
 
+  commits contains other types than fix
+
  date:  
  
  tag: name: 1.147.2
@@ -349,12 +356,16 @@ This reverts commit 1edc0d71eccce51abfb5f62fdddfbe73913785f5.
  
   commits contains fix
 
+  commits contains other types than fix
+
  date: 2021-05-24 
  
  tag: name: 1.147.1
   "name: 1.147.1" is a release tag
  
   commits contains fix
+
+  commits contains other types than fix
 
  date: 2021-05-23 
  
@@ -379,6 +390,7 @@ second-token-here: value of second token
  
  
  
+  commit has not type fix or revert 
 
  
 
@@ -403,6 +415,7 @@ Refs #133
   is type fix 
  
   commit has type fix or revert 
+ 
 
  
 
@@ -422,6 +435,7 @@ BREAKING CHANGE: &#x60;extends&#x60; key in config file is now used for extendin
  
  
  
+  commit has not type fix or revert 
 
  
 
@@ -441,6 +455,7 @@ BREAKING CHANGE: refactor to use JavaScript features not available in Node 6.
  
  
  
+  commit has not type fix or revert 
 
  
 
@@ -460,6 +475,7 @@ BREAKING CHANGE: refactor to use JavaScript features not available in Node 6.
  
  
  
+  commit has not type fix or revert 
 
  
 
@@ -477,6 +493,7 @@ BREAKING CHANGE: refactor to use JavaScript features not available in Node 6.
  
  
  
+  commit has not type fix or revert 
 
  
 
@@ -496,6 +513,7 @@ This reverts commit 1edc0d71eccce51abfb5f62fdddfbe73913785f5.
  
  
   commit has type fix or revert 
+ 
 
  
 
@@ -514,6 +532,7 @@ This reverts commit 1edc0d71eccce51abfb5f62fdddfbe73913785f5.
   is type fix 
  
   commit has type fix or revert 
+ 
 
   is scope utils 
 
@@ -534,6 +553,7 @@ This reverts commit 1edc0d71eccce51abfb5f62fdddfbe73913785f5.
  
  
  
+  commit has not type fix or revert 
 
   is scope utils 
 
@@ -552,6 +572,7 @@ This reverts commit 1edc0d71eccce51abfb5f62fdddfbe73913785f5.
  
   commit has no type 
  
+  commit has not type fix or revert 
 
  
 
@@ -569,6 +590,7 @@ This reverts commit 1edc0d71eccce51abfb5f62fdddfbe73913785f5.
  
   commit has no type 
  
+  commit has not type fix or revert 
 
  
 
@@ -586,6 +608,7 @@ This reverts commit 1edc0d71eccce51abfb5f62fdddfbe73913785f5.
   is type fix 
  
   commit has type fix or revert 
+ 
 
  
 
@@ -603,6 +626,7 @@ This reverts commit 1edc0d71eccce51abfb5f62fdddfbe73913785f5.
  
   commit has no type 
  
+  commit has not type fix or revert 
 
  
 
@@ -620,6 +644,7 @@ This reverts commit 1edc0d71eccce51abfb5f62fdddfbe73913785f5.
  
   commit has no type 
  
+  commit has not type fix or revert 
 
  
 
@@ -637,6 +662,7 @@ This reverts commit 1edc0d71eccce51abfb5f62fdddfbe73913785f5.
   is type fix 
  
   commit has type fix or revert 
+ 
 
  
 

--- a/src/test/resources/templatetest/helpers/testThatBuiltInHelperMethodsCanBeUsed.mustache
+++ b/src/test/resources/templatetest/helpers/testThatBuiltInHelperMethodsCanBeUsed.mustache
@@ -87,6 +87,10 @@ Has paragraphs: {{hash}}
   commits contains fix
  {{/ifContainsType}}
 
+ {{#ifContainsTypeOtherThan commits type="fix"}}
+  commits contains other types than fix
+ {{/ifContainsTypeOtherThan}}
+
  date: {{tagDate .}} 
  
 {{/tags}}
@@ -100,6 +104,7 @@ Has paragraphs: {{hash}}
  {{#ifCommitType . type="fix"}} is type fix {{/ifCommitType}}
  {{#ifCommitType . type=""}} commit has no type {{/ifCommitType}}
  {{#ifCommitType . type="fix|revert"}} commit has type fix or revert {{/ifCommitType}}
+ {{#ifCommitTypeOtherThan . type="fix|revert"}} commit has not type fix or revert {{/ifCommitTypeOtherThan}}
 
  {{#ifCommitScope . scope="utils"}} is scope utils {{/ifCommitScope}}
 


### PR DESCRIPTION
It would be nice to have additional built-in helpers that allow having a section in the changelog for commits that do not match certain types.

To achieve this I added to helper functions:

- "ifContainsTypeOtherThan" checks if a commit exists with a type, that does not match the given regular expression
- "ifCommitTypeOtherThan" checks if the type of the given commit does not match the given regular expression

(I am not so good at naming things ... thus if you have better naming ideas, I am happy to change it)

The template I have in mind, looks like the one below (I want to include all commits in the changelog, but only certain types should have their own section):

``` handlebars
{{#tags}}
{{#ifReleaseTag .}}
## [{{name}}](https://gitlab.com/html-validate/html-validate/compare/{{name}}) ({{tagDate .}})

  {{#ifContainsType commits type='feat'}}
    ### Features

    {{#commits}}
      {{#ifCommitType . type='feat'}}
  - {{#eachCommitScope .}} **{{.}}** {{/eachCommitScope}} {{{commitDescription .}}} ([{{hash}}](https://github.com/{{ownerName}}/{{repoName}}/commit/{{hash}}))
      {{/ifCommitType}}
    {{/commits}}
  {{/ifContainsType}}


  {{#ifContainsType commits type='fix'}}
    ### Bug Fixes

    {{#commits}}
      {{#ifCommitType . type='fix'}}
        - {{#eachCommitScope .}} **{{.}}** {{/eachCommitScope}} {{{commitDescription .}}} ([{{hash}}](https://github.com/{{ownerName}}/{{repoName}}/commit/{{hash}}))
      {{/ifCommitType}}
    {{/commits}}
  {{/ifContainsType}}

  {{#ifContainsTypeOtherThan commits type='feat|fix'}}
    ### Other

    {{#commits}}
      {{#ifCommitTypeOtherThan . type='feat|fix'}}
        - {{#eachCommitScope .}} **{{.}}** {{/eachCommitScope}} {{{commitDescription .}}} ([{{hash}}](https://github.com/{{ownerName}}/{{repoName}}/commit/{{hash}}))
      {{/ifCommitTypeOtherThan}}
    {{/commits}}
  {{/ifContainsTypeOtherThan}}

{{/ifReleaseTag}}
{{/tags}}
```

