### PR TITLE
Allow minus in scope for conventional commits

### DIFF
--- a/src/main/java/se/bjurr/gitchangelog/internal/semantic/ConventionalCommitParser.java
+++ b/src/main/java/se/bjurr/gitchangelog/internal/semantic/ConventionalCommitParser.java
@@ -13,7 +13,7 @@ import se.bjurr.gitchangelog.internal.model.Transformer;
 
 public class ConventionalCommitParser {
   private static final Pattern CONVENTIONAL_PATTERN =
-      Pattern.compile("^(\\w+)(\\(([\\w:]+)\\)?)?(\\!?):(.+)");
+      Pattern.compile("^(\\w+)(\\(([(\\w\\-):]+)\\)?)?(\\!?):(.+)");
   private static final Pattern FOOTER_PATTERN =
       Pattern.compile("^(BREAKING[ -]CHANGE|[^ ]+)(((: )|( #))(.+))");
 

--- a/src/main/java/se/bjurr/gitchangelog/internal/semantic/ConventionalCommitParser.java
+++ b/src/main/java/se/bjurr/gitchangelog/internal/semantic/ConventionalCommitParser.java
@@ -13,7 +13,7 @@ import se.bjurr.gitchangelog.internal.model.Transformer;
 
 public class ConventionalCommitParser {
   private static final Pattern CONVENTIONAL_PATTERN =
-      Pattern.compile("^(\\w+)(\\(([(\\w\\-):]+)\\)?)?(\\!?):(.+)");
+      Pattern.compile("^(\\w+)(\\(([\\w\\-:]+)\\)?)?(\\!?):(.+)");
   private static final Pattern FOOTER_PATTERN =
       Pattern.compile("^(BREAKING[ -]CHANGE|[^ ]+)(((: )|( #))(.+))");
 


### PR DESCRIPTION
This pull request extends the regular expression for conventional commits to allow the minus sign inside the scope.

In a project I am working on we use conventional commits of this form:

`feat(FOO-123): implement some feature`

FOO-123 is a ticket number in JIRA.

The frontend team has been using this convention for some time, so while the spec is not totally clear about this I consider it valid.