### PR TITLE
Allow comma in conventional commit scope

### DIFF
--- a/src/main/java/se/bjurr/gitchangelog/internal/semantic/ConventionalCommitParser.java
+++ b/src/main/java/se/bjurr/gitchangelog/internal/semantic/ConventionalCommitParser.java
@@ -16,7 +16,7 @@ import se.bjurr.gitchangelog.internal.model.Transformer;
 @SuppressFBWarnings("REDOS")
 public class ConventionalCommitParser {
   private static final Pattern CONVENTIONAL_PATTERN =
-      Pattern.compile("^(\\w+)(\\(([\\w\\-\\.:]+)\\)?)?(\\!?)[\\s?]*:(.+)");
+      Pattern.compile("^(\\w+)(\\(([\\w\\-\\.\\,:]+)\\)?)?(\\!?)[\\s?]*:(.+)");
 
   private static final Pattern FOOTER_PATTERN =
       Pattern.compile("^(BREAKING[ -]CHANGE|[^ ]+)(((: )|( #))(.+))");

--- a/src/test/java/se/bjurr/gitchangelog/internal/semantic/ConventionalCommitParserTest.java
+++ b/src/test/java/se/bjurr/gitchangelog/internal/semantic/ConventionalCommitParserTest.java
@@ -33,6 +33,6 @@ public class ConventionalCommitParserTest {
     assertThat(ConventionalCommitParser.commitScopes("feat(123) : add polish language"))
         .containsOnly("123");
     assertThat(ConventionalCommitParser.commitScopes("feat(namespaceA,namespaceB): add polish language"))
-            .containsOnly("namespaceA,namespaceB");
+        .containsOnly("namespaceA,namespaceB");
   }
 }

--- a/src/test/java/se/bjurr/gitchangelog/internal/semantic/ConventionalCommitParserTest.java
+++ b/src/test/java/se/bjurr/gitchangelog/internal/semantic/ConventionalCommitParserTest.java
@@ -32,5 +32,7 @@ public class ConventionalCommitParserTest {
         .containsOnly("org.test");
     assertThat(ConventionalCommitParser.commitScopes("feat(123) : add polish language"))
         .containsOnly("123");
+    assertThat(ConventionalCommitParser.commitScopes("feat(namespaceA,namespaceB): add polish language"))
+            .containsOnly("namespaceA,namespaceB");
   }
 }


### PR DESCRIPTION
Hello,

some of our projects have commits where their scope includes more than one namespace separated by comma (`,`) to reflect all namespaces affected by committed changes.

For example `feat(namespaceA,namespaceB): updated app and lib`.
Unfortunately as of now there is no RegExp match on this scope.

The proposed change allows usage of comma (`,`) in the scope part of the commit by adding it to the RegExp in the `CONVENTIONAL_PATTERN` variable.

Test case is also included.