### PR TITLE
fix: reverse list for eachUrlPart

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,9 +167,7 @@ Some [helpers](/src/main/java/se/bjurr/gitchangelog/api/helpers) are implemented
 Loop each part of the URL.
 
 ```hbs
-{{#eachUrlPart .}}
-{{@index}}: {{.}}
-{{/eachUrlPart}}
+https://gitlab.com/{{#eachUrlPart .}}{{#if @first}}{{else}}{{.}}/{{/if}}{{/eachUrlPart}}
 ```
 
 ### `ifReleaseTag <Tag>`

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 #
-#Sat Jan 18 07:59:25 CET 2025
+#Sat Jan 25 19:50:49 CST 2025
 description='Library for parsing report files from static code analysis'
 group=se.bjurr.gitchangelog
 sourceCompatibility=17
 targetCompatibility=17
-version=2.5.0
+version=2.5.1

--- a/src/main/java/se/bjurr/gitchangelog/api/helpers/Helpers.java
+++ b/src/main/java/se/bjurr/gitchangelog/api/helpers/Helpers.java
@@ -28,6 +28,7 @@ import com.github.jknack.handlebars.Options;
 import com.github.jknack.handlebars.Options.Buffer;
 import com.github.jknack.handlebars.helper.EachHelper;
 import java.io.IOException;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
@@ -242,6 +243,7 @@ public class Helpers {
     helpers.put(
         "eachUrlPart",
         (final Changelog changelog, final Options options) -> {
+          Collections.reverse(changelog.getUrlParts());
           return each(options, changelog.getUrlParts());
         });
     return helpers;

--- a/src/test/java/se/bjurr/gitchangelog/api/TemplatesTest.testEachUrlPart.approved.txt
+++ b/src/test/java/se/bjurr/gitchangelog/api/TemplatesTest.testEachUrlPart.approved.txt
@@ -3,9 +3,7 @@ template:
 ownerName: {{ownerName}}
 repoName: {{repoName}}
 urlParts: {{urlParts}}
-{{#eachUrlPart .}}
-{{@index}}: {{.}}
-{{/eachUrlPart}}
+https://github.com/{{#eachUrlPart .}}{{#if @first}}{{else}}{{.}}/{{/if}}{{/eachUrlPart}}
 
 ---------------------------------------------
 
@@ -72,10 +70,7 @@ changelog:
 ownerName: tomasbjerre
 repoName: git-changelog-lib
 urlParts: [git-changelog-lib, tomasbjerre, git@github.com]
-0: git-changelog-lib
-1: tomasbjerre
-2: git@github.com
-
+https://github.com/tomasbjerre/git-changelog-lib/
 
 ---------------------------------------------
 

--- a/src/test/resources/templatetest/testEachUrlPart.mustache
+++ b/src/test/resources/templatetest/testEachUrlPart.mustache
@@ -1,6 +1,4 @@
 ownerName: {{ownerName}}
 repoName: {{repoName}}
 urlParts: {{urlParts}}
-{{#eachUrlPart .}}
-{{@index}}: {{.}}
-{{/eachUrlPart}}
+https://github.com/{{#eachUrlPart .}}{{#if @first}}{{else}}{{.}}/{{/if}}{{/eachUrlPart}}


### PR DESCRIPTION
`eachUrlPart` should return the reverse of `urlParts` so that a caller can properly construct the url via a loop.

urlParts = [git-changelog-lib, tomasbjerre, git@github.com]

someTemplate.mustache

```hbs
https://github.com/{{#eachUrlPart .}}{{#if @first}}{{else}}{{.}}/{{/if}}{{/eachUrlPart}}
```

output
```
https://github.com/tomasbjerre/git-changelog-lib/
```