### PR TITLE
fix: Include other Conventional Commit types

### DIFF
--- a/src/main/java/se/bjurr/gitchangelog/api/helpers/Helpers.java
+++ b/src/main/java/se/bjurr/gitchangelog/api/helpers/Helpers.java
@@ -172,6 +172,11 @@ public class Helpers {
         (final Commit commit, final Options options) -> {
           return conditional(options, commitScope(commit, options));
         });
+    helpers.put(
+        "ifCommitTypeOtherThan",
+        (final Commit commit, final Options options) -> {
+          return conditional(options, !commitScope(commit, options));
+        });
 
     helpers.put(
         "ifCommitHasFooters",

--- a/src/main/resources/changelog-prepend.mustache
+++ b/src/main/resources/changelog-prepend.mustache
@@ -46,7 +46,7 @@
 ### Other changes
 
 {{#commits}}
-{{#ifCommitType . type='^$'}}
+{{#ifCommitType . type='^($^|(?!fix|feat|breaking|chore).*)'}}
 **{{{messageTitle}}}**
 
 {{#messageBodyItems}}
@@ -55,6 +55,18 @@
 
 [{{subString hash 0 5}}](https://github.com/{{ownerName}}/{{repoName}}/commit/{{hash}}) {{authorName}} *{{commitTime}}*
 
+{{/ifCommitType}}
+{{#ifCommitType . type="chore"}}
+{{#ifCommitTypeOtherThan . scope="deps"}}
+**{{{messageTitle}}}**
+
+{{#messageBodyItems}}
+* {{.}}
+{{/messageBodyItems}}
+
+[{{subString hash 0 5}}](https://github.com/{{ownerName}}/{{repoName}}/commit/{{hash}}) {{authorName}} *{{commitTime}}*
+
+{{/ifCommitTypeOtherThan}}
 {{/ifCommitType}}
 {{/commits}}
 

--- a/src/main/resources/changelog.mustache
+++ b/src/main/resources/changelog.mustache
@@ -51,7 +51,7 @@ Changelog of {{repoName}}.
 ### Other changes
 
 {{#commits}}
-{{#ifCommitType . type='^$'}}
+{{#ifCommitType . type='^($^|(?!fix|feat|breaking|chore).*)'}}
 **{{{messageTitle}}}**
 
 {{#messageBodyItems}}
@@ -60,6 +60,18 @@ Changelog of {{repoName}}.
 
 [{{subString hash 0 5}}](https://github.com/{{ownerName}}/{{repoName}}/commit/{{hash}}) {{authorName}} *{{commitTime}}*
 
+{{/ifCommitType}}
+{{#ifCommitType . type="chore"}}
+{{#ifCommitTypeOtherThan . scope="deps"}}
+**{{{messageTitle}}}**
+
+{{#messageBodyItems}}
+* {{.}}
+{{/messageBodyItems}}
+
+[{{subString hash 0 5}}](https://github.com/{{ownerName}}/{{repoName}}/commit/{{hash}}) {{authorName}} *{{commitTime}}*
+
+{{/ifCommitTypeOtherThan}}
 {{/ifCommitType}}
 {{/commits}}
 


### PR DESCRIPTION
As mentioned on https://www.conventionalcommits.org/en/v1.0.0/ other commit types are allowed. For example `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`.

Currently the `changelog.mustache` template would drop commits that aren't `fix|feat|breaking|chore`, and we would probably like to see them in the `Other Changes` section.